### PR TITLE
Grant mediawiki instance access to route53

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -27,7 +27,7 @@ resource "aws_launch_template" "base" {
   }
 
   iam_instance_profile {
-    arn = aws_iam_instance_profile.amazon_s3_access.arn
+    arn = aws_iam_instance_profile.mediawiki.arn
   }
 
   tag_specifications {
@@ -68,7 +68,7 @@ resource "aws_launch_template" "mediawiki" {
   }
 
   iam_instance_profile {
-    arn = aws_iam_instance_profile.amazon_s3_access.arn
+    arn = aws_iam_instance_profile.mediawiki.arn
   }
 
   tag_specifications {
@@ -86,9 +86,9 @@ resource "aws_launch_template" "mediawiki" {
   }
 }
 
-resource "aws_iam_instance_profile" "amazon_s3_access" {
-  name = "AmazonS3Access"
-  role = aws_iam_role.amazon_s3_access.name
+resource "aws_iam_instance_profile" "mediawiki" {
+  name = "MediaWiki"
+  role = aws_iam_role.mediawiki.name
 }
 
 resource "aws_instance" "mediawiki" {
@@ -97,7 +97,7 @@ resource "aws_instance" "mediawiki" {
   instance_type        = "t3.micro"
   key_name             = aws_key_pair.femiwiki.key_name
   monitoring           = false
-  iam_instance_profile = aws_iam_instance_profile.amazon_s3_access.name
+  iam_instance_profile = aws_iam_instance_profile.mediawiki.name
 
   vpc_security_group_ids = [
     aws_default_security_group.default.id,

--- a/iam.tf
+++ b/iam.tf
@@ -47,15 +47,15 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
-resource "aws_iam_role" "amazon_s3_access" {
-  name               = "AmazonS3Access"
+resource "aws_iam_role" "mediawiki" {
+  name               = "MediaWiki"
   description        = "Allows EC2 instances to call AWS services on your behalf."
   path               = "/"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_s3_access" {
-  role       = aws_iam_role.amazon_s3_access.name
+  role       = aws_iam_role.mediawiki.name
   policy_arn = aws_iam_policy.amazon_s3_access.arn
 }
 
@@ -89,6 +89,36 @@ resource "aws_iam_policy" "amazon_s3_access" {
   description = "Provide Access to Amazon S3 buckets."
 
   policy = data.aws_iam_policy_document.amazon_s3_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "route53" {
+  role       = aws_iam_role.mediawiki.name
+  policy_arn = aws_iam_policy.route53.arn
+}
+
+data "aws_iam_policy_document" "route53" {
+  statement {
+    actions = [
+      "route53:GetHostedZone",
+      "route53:ListResourceRecordSets",
+      "route53:ChangeResourceRecordSets",
+    ]
+    resources = ["arn:aws:route53:::hostedzone/${aws_route53_zone.femiwiki_com.zone_id}"]
+  }
+
+  statement {
+    actions = [
+      "route53:GetChange",
+    ]
+    resources = ["arn:aws:route53:::change/*"]
+  }
+}
+
+resource "aws_iam_policy" "route53" {
+  name        = "Route53Access"
+  description = "Provide Access to route53."
+
+  policy = data.aws_iam_policy_document.route53.json
 }
 
 resource "aws_iam_policy" "force_mfa" {

--- a/sg.tf
+++ b/sg.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "mediawiki" {
   }
 }
 
-resource "aws_security_group_rule" "mediawiki_ingress" {
+resource "aws_security_group_rule" "mediawiki_ingress_http" {
   security_group_id = aws_security_group.mediawiki.id
   description       = "http from load balancer"
 
@@ -99,7 +99,20 @@ resource "aws_security_group_rule" "mediawiki_ingress" {
   protocol                 = "tcp"
   from_port                = 80
   to_port                  = 80
-  source_security_group_id = aws_security_group.loadbalancer.id
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+resource "aws_security_group_rule" "mediawiki_ingress_https" {
+  security_group_id = aws_security_group.mediawiki.id
+  description       = "https from load balancer"
+
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 443
+  to_port                  = 443
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
 }
 
 resource "aws_security_group_rule" "mediawiki_egress" {


### PR DESCRIPTION
https://github.com/femiwiki/femiwiki/issues/93

### Grant mediawiki instance access to route53

mediawiki instance와 그 런치 템플릿에게 Caddy가 route53을 써서 DNS-01 챌린지를 할 수 있는 정책을 추가합니다. 정책에 사용된, 다음 표에서 왼쪽에 나타나 있는 액션은 오른쪽 코드에서 사용되는 것을 확인했습니다.

| 액션                               | 코드                                                                               |
| ---------------------------------- | ---------------------------------------------------------------------------------- |
| `route53:GetHostedZone`            | [go-acme/lego/providers/dns/route53/route53.go#L256](https://github.com/go-acme/lego/blob/635b9ac/providers/dns/route53/route53.go#L256) |
| `route53:ListResourceRecordSets`   | [go-acme/lego/providers/dns/route53/route53.go#L222](https://github.com/go-acme/lego/blob/635b9ac/providers/dns/route53/route53.go#L222) |
| `route53:ChangeResourceRecordSets` | [go-acme/lego/providers/dns/route53/route53.go#L193](https://github.com/go-acme/lego/blob/635b9ac/providers/dns/route53/route53.go#L193) |
| `route53:GetChange`                  | [go-acme/lego/providers/dns/route53/route53.go#L203](https://github.com/go-acme/lego/blob/635b9ac/providers/dns/route53/route53.go#L203) |

또 기존 `mediawiki` 인스턴스는 S3 버킷 접근만 가능하여, 해당 인스턴스 프로필 이름도 S3 관련으로 지었었는데 여기에 route53 권한이 추가되어 이름을 MediaWiki로 바꿨습니다.

### Enable inbound HTTPS connections

TBD.

### `terraform plan`

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_iam_instance_profile.amazon_s3_access will be destroyed
  - resource "aws_iam_instance_profile" "amazon_s3_access" {
      - arn         = "arn:aws:iam::302617221463:instance-profile/AmazonS3Access" -> null
      - create_date = "2018-10-06T09:46:19Z" -> null
      - id          = "AmazonS3Access" -> null
      - name        = "AmazonS3Access" -> null
      - path        = "/" -> null
      - role        = "AmazonS3Access" -> null
      - roles       = [
          - "AmazonS3Access",
        ] -> null
      - unique_id   = "AIPAIPJL5EFNBDRF7OKZG" -> null
    }

  # aws_iam_instance_profile.mediawiki will be created
  + resource "aws_iam_instance_profile" "mediawiki" {
      + arn         = (known after apply)
      + create_date = (known after apply)
      + id          = (known after apply)
      + name        = "MediaWiki"
      + path        = "/"
      + role        = "MediaWiki"
      + roles       = (known after apply)
      + unique_id   = (known after apply)
    }

  # aws_iam_policy.route53 will be created
  + resource "aws_iam_policy" "route53" {
      + arn         = (known after apply)
      + description = "Provide Access to route53."
      + id          = (known after apply)
      + name        = "Route53Access"
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "route53:ListResourceRecordSets",
                          + "route53:GetHostedZone",
                          + "route53:ChangeResourceRecordSets",
                        ]
                      + Effect   = "Allow"
                      + Resource = "arn:aws:route53:::hostedzone/Z1IOLPZGUQYUUT"
                      + Sid      = ""
                    },
                  + {
                      + Action   = "route53:GetChange"
                      + Effect   = "Allow"
                      + Resource = "arn:aws:route53:::change/*"
                      + Sid      = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
    }

  # aws_iam_role.amazon_s3_access will be destroyed
  - resource "aws_iam_role" "amazon_s3_access" {
      - arn                   = "arn:aws:iam::302617221463:role/AmazonS3Access" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "ec2.amazonaws.com"
                        }
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2018-10-06T09:46:18Z" -> null
      - description           = "Allows EC2 instances to call AWS services on your behalf." -> null
      - force_detach_policies = false -> null
      - id                    = "AmazonS3Access" -> null
      - max_session_duration  = 3600 -> null
      - name                  = "AmazonS3Access" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - unique_id             = "AROAIPDUBLZE4BKXUQJHC" -> null
    }

  # aws_iam_role.mediawiki will be created
  + resource "aws_iam_role" "mediawiki" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ec2.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + description           = "Allows EC2 instances to call AWS services on your behalf."
      + force_detach_policies = false
      + id                    = (known after apply)
      + max_session_duration  = 3600
      + name                  = "MediaWiki"
      + path                  = "/"
      + unique_id             = (known after apply)
    }

  # aws_iam_role_policy_attachment.amazon_s3_access must be replaced
-/+ resource "aws_iam_role_policy_attachment" "amazon_s3_access" {
      ~ id         = "AmazonS3Access-arn:aws:iam::302617221463:policy/AmazonS3Access" -> (known after apply)
        policy_arn = "arn:aws:iam::302617221463:policy/AmazonS3Access"
      ~ role       = "AmazonS3Access" -> "MediaWiki" # forces replacement
    }

  # aws_iam_role_policy_attachment.route53 will be created
  + resource "aws_iam_role_policy_attachment" "route53" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "MediaWiki"
    }

  # aws_instance.mediawiki will be updated in-place
  ~ resource "aws_instance" "mediawiki" {
        ami                          = "ami-0a20c8152821c73ba"
        arn                          = "arn:aws:ec2:ap-northeast-1:302617221463:instance/i-0449b4506bbde43ad"
        associate_public_ip_address  = true
        availability_zone            = "ap-northeast-1a"
        cpu_core_count               = 1
        cpu_threads_per_core         = 2
        disable_api_termination      = false
        ebs_optimized                = true
        get_password_data            = false
      ~ iam_instance_profile         = "AmazonS3Access" -> "MediaWiki"
        id                           = "i-0449b4506bbde43ad"
        instance_state               = "running"
        instance_type                = "t3.micro"
        ipv6_address_count           = 0
        ipv6_addresses               = []
        key_name                     = "femiwiki-2018-09-15"
        monitoring                   = false
        primary_network_interface_id = "eni-032377940102aa394"
        private_dns                  = "ip-172-31-23-1.ap-northeast-1.compute.internal"
        private_ip                   = "172.31.23.1"
        public_dns                   = "ec2-13-230-63-68.ap-northeast-1.compute.amazonaws.com"
        public_ip                    = "13.230.63.68"
        security_groups              = [
            "default",
            "internal-http-server",
            "public http server",
        ]
        source_dest_check            = true
        subnet_id                    = "subnet-9da70beb"
        tags                         = {
            "Name" = "mediawiki"
        }
        tenancy                      = "default"
        volume_tags                  = {
            "Name" = "mediawiki"
        }
        vpc_security_group_ids       = [
            "sg-03aebf67",
            "sg-07644ee8da7b994d2",
            "sg-07e51fb6f6719fc57",
        ]

        credit_specification {
            cpu_credits = "unlimited"
        }

        root_block_device {
            delete_on_termination = true
            encrypted             = false
            iops                  = 0
            volume_id             = "vol-02a8598cb2d3f7457"
            volume_size           = 16
            volume_type           = "standard"
        }

        timeouts {}
    }

  # aws_launch_template.base will be updated in-place
  ~ resource "aws_launch_template" "base" {
        arn                                  = "arn:aws:ec2:ap-northeast-1:302617221463:launch-template/lt-05b2839165e4bd8e3"
        default_version                      = 1
        description                          = "Base Launch Template"
        disable_api_termination              = true
        ebs_optimized                        = "true"
        id                                   = "lt-05b2839165e4bd8e3"
        image_id                             = "ami-0019c8208fd95e551"
        instance_initiated_shutdown_behavior = "stop"
        instance_type                        = "t3.nano"
        key_name                             = "femiwiki-2018-09-15"
      ~ latest_version                       = 2 -> (known after apply)
        name                                 = "base"
        security_group_names                 = []
        tags                                 = {}
        vpc_security_group_ids               = [
            "sg-03aebf67",
            "sg-07e51fb6f6719fc57",
        ]

        block_device_mappings {
            device_name = "/dev/xvda"

            ebs {
                delete_on_termination = "false"
                iops                  = 0
                snapshot_id           = "snap-0de1ef9e4ea75d3a0"
                volume_size           = 16
                volume_type           = "gp2"
            }
        }

      ~ iam_instance_profile {
          ~ arn = "arn:aws:iam::302617221463:instance-profile/AmazonS3Access" -> (known after apply)
        }

        tag_specifications {
            resource_type = "instance"
            tags          = {
                "Name" = "database+bots"
            }
        }
        tag_specifications {
            resource_type = "volume"
            tags          = {
                "Name" = "database+bots"
            }
        }
    }

  # aws_launch_template.mediawiki will be updated in-place
  ~ resource "aws_launch_template" "mediawiki" {
        arn                                  = "arn:aws:ec2:ap-northeast-1:302617221463:launch-template/lt-096ae472b21d7e890"
        default_version                      = 4
        description                          = "A launch template for mediawiki servers"
        disable_api_termination              = true
        ebs_optimized                        = "true"
        id                                   = "lt-096ae472b21d7e890"
        image_id                             = "ami-0a20c8152821c73ba"
        instance_initiated_shutdown_behavior = "terminate"
        instance_type                        = "t3.micro"
        key_name                             = "femiwiki-2018-09-15"
      ~ latest_version                       = 6 -> (known after apply)
        name                                 = "mediawiki"
        security_group_names                 = []
        tags                                 = {}
        vpc_security_group_ids               = [
            "sg-03aebf67",
            "sg-07e51fb6f6719fc57",
        ]

        block_device_mappings {
            device_name = "/dev/xvda"

            ebs {
                delete_on_termination = "true"
                iops                  = 0
                snapshot_id           = "snap-04d7ba812a8811e72"
                volume_size           = 16
                volume_type           = "standard"
            }
        }

      ~ iam_instance_profile {
          ~ arn = "arn:aws:iam::302617221463:instance-profile/AmazonS3Access" -> (known after apply)
        }

        tag_specifications {
            resource_type = "instance"
            tags          = {
                "Name" = "mediawiki"
            }
        }
        tag_specifications {
            resource_type = "volume"
            tags          = {
                "Name" = "mediawiki"
            }
        }
    }

  # aws_security_group_rule.mediawiki_ingress will be destroyed
  - resource "aws_security_group_rule" "mediawiki_ingress" {
      - cidr_blocks              = [] -> null
      - description              = "http from load balancer" -> null
      - from_port                = 80 -> null
      - id                       = "sgrule-2787666972" -> null
      - ipv6_cidr_blocks         = [] -> null
      - prefix_list_ids          = [] -> null
      - protocol                 = "tcp" -> null
      - security_group_id        = "sg-07e51fb6f6719fc57" -> null
      - self                     = false -> null
      - source_security_group_id = "sg-07644ee8da7b994d2" -> null
      - to_port                  = 80 -> null
      - type                     = "ingress" -> null
    }

  # aws_security_group_rule.mediawiki_ingress_http will be created
  + resource "aws_security_group_rule" "mediawiki_ingress_http" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "http from load balancer"
      + from_port                = 80
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + protocol                 = "tcp"
      + security_group_id        = "sg-07e51fb6f6719fc57"
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

  # aws_security_group_rule.mediawiki_ingress_https will be created
  + resource "aws_security_group_rule" "mediawiki_ingress_https" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "https from load balancer"
      + from_port                = 443
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + protocol                 = "tcp"
      + security_group_id        = "sg-07e51fb6f6719fc57"
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

Plan: 7 to add, 3 to change, 4 to destroy.
```