### PR TITLE
Github: Unprotect docker-mediawiki

### DIFF
--- a/github/repo.tf
+++ b/github/repo.tf
@@ -187,15 +187,16 @@ resource "github_repository" "docker_mediawiki" {
   ]
 }
 
-resource "github_branch_protection" "mediawiki" {
-  repository     = github_repository.docker_mediawiki.name
-  branch         = "master"
-  enforce_admins = true
-
-  required_pull_request_reviews {
-    required_approving_review_count = 1
-  }
-}
+# https://github.com/femiwiki/infra/issues/59
+# resource "github_branch_protection" "mediawiki" {
+#   repository     = github_repository.docker_mediawiki.name
+#   branch         = "master"
+#   enforce_admins = true
+#
+#   required_pull_request_reviews {
+#     required_approving_review_count = 1
+#   }
+# }
 
 resource "github_team_repository" "mediawiki" {
   team_id    = github_team.reviewer.id


### PR DESCRIPTION
Docker Image와 Compose를 같은 리포 안에서 취급하고 있어 Deploy시 불편함이 있어, Kubernetes 쓰기 전까지는 임시로 보호를 해제합니다.

Related to https://github.com/femiwiki/infra/issues/59