### PR TITLE
AWS: Bump k3s version to v1.17.4+k3s1

### DIFF
--- a/aws/res/bootstrap.sh
+++ b/aws/res/bootstrap.sh
@@ -52,7 +52,7 @@ sudo mount -a
 # k3s 설치
 #
 curl -sfL https://get.k3s.io |
-  INSTALL_K3S_VERSION='v1.17.2+k3s1' \
+  INSTALL_K3S_VERSION='v1.17.4+k3s1' \
   INSTALL_K3S_EXEC='server --write-kubeconfig-mode 644' \
   sh
 # Reference: https://rancher.com/docs/k3s/latest/en/installation/install-options


### PR DESCRIPTION
[K3s Changelog](https://github.com/rancher/k3s/releases/tag/v1.17.4%2Bk3s1)