### PR TITLE
github: Use the github_branch_default resource instead of deprecated default_branch

### DIFF
--- a/github/repo.tf
+++ b/github/repo.tf
@@ -1,7 +1,6 @@
 locals {
   default_repo = {
     # repository
-    default_branch       = "main",
     has_issues           = true,
     vulnerability_alerts = true,
     archive_on_destroy   = true,
@@ -31,10 +30,19 @@ locals {
 resource "github_repository" "infra" {
   name                 = "infra"
   description          = ":evergreen_tree: Terraforming Femiwiki Infrastructure"
-  default_branch       = local.with_cd.default_branch
   has_issues           = local.with_cd.has_issues
   vulnerability_alerts = local.with_cd.vulnerability_alerts
   archive_on_destroy   = local.with_cd.archive_on_destroy
+}
+
+resource "github_branch" "infra_main" {
+  repository = github_repository.infra
+  branch     = "main"
+}
+
+resource "github_branch_default" "infra" {
+  repository = github.repository.infra
+  branch     = github.branch.infra_main
 }
 
 resource "github_branch_protection" "infra" {
@@ -61,10 +69,19 @@ resource "github_team_repository" "infra" {
 resource "github_repository" "nomad" {
   name                 = "nomad"
   description          = ":whale: Femiwiki nomad"
-  default_branch       = local.with_cd.default_branch
   has_issues           = local.with_cd.has_issues
   vulnerability_alerts = local.with_cd.vulnerability_alerts
   archive_on_destroy   = local.with_cd.archive_on_destroy
+}
+
+resource "github_branch" "nomad_main" {
+  repository = github_repository.nomad
+  branch     = "master"
+}
+
+resource "github_branch_default" "nomad" {
+  repository = github.repository.nomad
+  branch     = github.branch.nomad_main
 }
 
 resource "github_branch_protection" "nomad" {
@@ -92,7 +109,6 @@ resource "github_repository" "femiwiki" {
   name                 = "femiwiki"
   description          = ":earth_asia: 문서화된 페미위키 기술 정보 및 이슈 트래킹 정보 제공"
   homepage_url         = "https://femiwiki.com"
-  default_branch       = local.default_repo.default_branch
   has_issues           = local.default_repo.has_issues
   vulnerability_alerts = local.default_repo.vulnerability_alerts
   archive_on_destroy   = local.default_repo.archive_on_destroy
@@ -101,6 +117,16 @@ resource "github_repository" "femiwiki" {
     "feminism",
     "wiki",
   ]
+}
+
+resource "github_branch" "femiwiki_main" {
+  repository = github_repository.femiwiki
+  branch     = "main"
+}
+
+resource "github_branch_default" "femiwiki" {
+  repository = github.repository.femiwiki
+  branch     = github.branch.femiwiki_main
 }
 
 resource "github_branch_protection" "femiwiki" {
@@ -128,7 +154,6 @@ resource "github_repository" "docker_mediawiki" {
   name                   = "docker-mediawiki"
   description            = ":whale: Dockerized Femiwiki's mediawiki server"
   delete_branch_on_merge = true
-  default_branch         = local.docker.default_branch
   has_issues             = local.docker.has_issues
   vulnerability_alerts   = local.docker.vulnerability_alerts
   archive_on_destroy     = local.docker.archive_on_destroy
@@ -138,6 +163,16 @@ resource "github_repository" "docker_mediawiki" {
     "server",
     "wiki",
   ]
+}
+
+resource "github_branch" "mediawiki_main" {
+  repository = github_repository.mediawiki
+  branch     = "main"
+}
+
+resource "github_branch_default" "mediawiki" {
+  repository = github.repository.mediawiki
+  branch     = github.branch.mediawiki_main
 }
 
 resource "github_branch_protection" "mediawiki" {
@@ -165,7 +200,6 @@ resource "github_team_repository" "mediawiki" {
 resource "github_repository" "docker_parsoid" {
   name                 = "docker-parsoid"
   description          = ":whale: Dockerized parsoid"
-  default_branch       = local.docker.default_branch
   has_issues           = local.docker.has_issues
   vulnerability_alerts = local.docker.vulnerability_alerts
   archive_on_destroy   = local.docker.archive_on_destroy
@@ -173,6 +207,16 @@ resource "github_repository" "docker_parsoid" {
     "docker-image",
     "parsoid",
   ]
+}
+
+resource "github_branch" "parsoid_main" {
+  repository = github_repository.parsoid
+  branch     = "main"
+}
+
+resource "github_branch_default" "parsoid" {
+  repository = github.repository.parsoid
+  branch     = github.branch.parsoid_main
 }
 
 resource "github_branch_protection" "parsoid" {
@@ -199,7 +243,6 @@ resource "github_team_repository" "parsoid" {
 resource "github_repository" "docker_restbase" {
   name                 = "docker-restbase"
   description          = "📝 Dockerized RESTBase"
-  default_branch       = local.docker.default_branch
   has_issues           = local.docker.has_issues
   vulnerability_alerts = local.docker.vulnerability_alerts
   archive_on_destroy   = local.docker.archive_on_destroy
@@ -207,6 +250,16 @@ resource "github_repository" "docker_restbase" {
     "docker-image",
     "restbase"
   ]
+}
+
+resource "github_branch" "docker_restbase_main" {
+  repository = github_repository.docker_restbase
+  branch     = "main"
+}
+
+resource "github_branch_default" "docker_restbase" {
+  repository = github.repository.docker_restbase
+  branch     = github.branch.docker_restbase_main
 }
 
 resource "github_branch_protection" "docker_restbase" {
@@ -233,7 +286,6 @@ resource "github_team_repository" "docker_restbase" {
 resource "github_repository" "docker_mathoid" {
   name                 = "docker-mathoid"
   description          = "📝 Dockerized Mathoid"
-  default_branch       = local.docker.default_branch
   has_issues           = local.docker.has_issues
   vulnerability_alerts = local.docker.vulnerability_alerts
   archive_on_destroy   = local.docker.archive_on_destroy
@@ -241,6 +293,16 @@ resource "github_repository" "docker_mathoid" {
     "docker-image",
     "mathoid"
   ]
+}
+
+resource "github_branch" "docker_mathoid_main" {
+  repository = github_repository.docker_mathoid
+  branch     = "main"
+}
+
+resource "github_branch_default" "docker_mathoid" {
+  repository = github.repository.docker_mathoid
+  branch     = github.branch.docker_mathoid_main
 }
 
 resource "github_branch_protection" "docker_mathoid" {
@@ -268,7 +330,6 @@ resource "github_repository" "rankingbot" {
   name                 = "rankingbot"
   description          = ":robot: 랭킹봇"
   homepage_url         = "https://femiwiki.com/w/%EC%82%AC%EC%9A%A9%EC%9E%90:%EB%9E%AD%ED%82%B9%EB%B4%87"
-  default_branch       = local.bot.default_branch
   has_issues           = local.bot.has_issues
   vulnerability_alerts = local.bot.vulnerability_alerts
   archive_on_destroy   = local.bot.archive_on_destroy
@@ -276,6 +337,16 @@ resource "github_repository" "rankingbot" {
     "bot",
     "docker-image",
   ]
+}
+
+resource "github_branch" "rankingbot_main" {
+  repository = github_repository.rankingbot
+  branch     = "main"
+}
+
+resource "github_branch_default" "rankingbot" {
+  repository = github.repository.rankingbot
+  branch     = github.branch.rankingbot_main
 }
 
 resource "github_branch_protection" "rankingbot" {
@@ -302,7 +373,6 @@ resource "github_team_repository" "rankingbot" {
 resource "github_repository" "backupbot" {
   name                 = "backupbot"
   description          = ":robot: 페미위키 MySQL 백업봇"
-  default_branch       = local.bot.default_branch
   has_issues           = local.bot.has_issues
   vulnerability_alerts = local.bot.vulnerability_alerts
   archive_on_destroy   = local.bot.archive_on_destroy
@@ -310,6 +380,16 @@ resource "github_repository" "backupbot" {
     "bot",
     "docker-image",
   ]
+}
+
+resource "github_branch" "backupbot_main" {
+  repository = github_repository.backupbot
+  branch     = "main"
+}
+
+resource "github_branch_default" "backupbot" {
+  repository = github.repository.backupbot
+  branch     = github.branch.backupbot_main
 }
 
 resource "github_branch_protection" "backupbot" {
@@ -337,7 +417,6 @@ resource "github_repository" "tweetbot" {
   name                 = "tweetbot"
   description          = ":robot: 페미위키 트위터 봇"
   homepage_url         = "https://femiwiki.com/w/%EC%82%AC%EC%9A%A9%EC%9E%90:%ED%8A%B8%EC%9C%97%EB%B4%87"
-  default_branch       = local.bot.default_branch
   has_issues           = local.bot.has_issues
   vulnerability_alerts = local.bot.vulnerability_alerts
   archive_on_destroy   = local.bot.archive_on_destroy
@@ -345,6 +424,16 @@ resource "github_repository" "tweetbot" {
     "bot",
     "docker-image",
   ]
+}
+
+resource "github_branch" "tweetbot_main" {
+  repository = github_repository.tweetbot
+  branch     = "main"
+}
+
+resource "github_branch_default" "tweetbot" {
+  repository = github.repository.tweetbot
+  branch     = github.branch.tweetbot_main
 }
 
 resource "github_branch_protection" "tweetbot" {
@@ -371,11 +460,20 @@ resource "github_team_repository" "tweetbot" {
 resource "github_repository" "remote_gadgets" {
   name                 = "remote-gadgets"
   description          = "📽️ External repository for Javascript/CSS on FemiWiki"
-  default_branch       = local.default_repo.default_branch
   has_issues           = local.default_repo.has_issues
   vulnerability_alerts = local.default_repo.vulnerability_alerts
   archive_on_destroy   = local.default_repo.archive_on_destroy
   topics               = ["bot"]
+}
+
+resource "github_branch" "remote_gadgets_main" {
+  repository = github_repository.remote_gadgets
+  branch     = "main"
+}
+
+resource "github_branch_default" "remote_gadgets" {
+  repository = github.repository.remote_gadgets
+  branch     = github.branch.remote_gadgets_main
 }
 
 resource "github_branch_protection" "remote_gadgets" {
@@ -402,10 +500,19 @@ resource "github_team_repository" "remote_gadgets" {
 resource "github_repository" "dot_github" {
   name                 = ".github"
   description          = "Community health files"
-  default_branch       = local.default_repo.default_branch
   has_issues           = local.default_repo.has_issues
   vulnerability_alerts = local.default_repo.vulnerability_alerts
   archive_on_destroy   = local.default_repo.archive_on_destroy
+}
+
+resource "github_branch" "dot_github_main" {
+  repository = github_repository.dot_github
+  branch     = "main"
+}
+
+resource "github_branch_default" "dot_github" {
+  repository = github.repository.dot_github
+  branch     = github.branch.dot_github_main
 }
 
 resource "github_branch_protection" "dot_github" {
@@ -433,10 +540,19 @@ resource "github_team_repository" "dot_github" {
 # resource "github_repository" "legunto" {
 #   name                 = "legunto"
 #   description          = "Fetch MediaWiki Scribunto modules from wikis"
-#   default_branch       = local.default_repo.default_branch
 #   has_issues           = local.default_repo.has_issues
 #   vulnerability_alerts = local.default_repo.vulnerability_alerts
 #   archive_on_destroy   = local.default_repo.archive_on_destroy
+# }
+
+# resource "github_branch" "legunto_main" {
+#   repository = github_repository.legunto
+#   branch     = "main"
+# }
+
+# resource "github_branch_default" "legunto" {
+#   repository = github.repository.legunto
+#   branch     = github.branch.legunto_main
 # }
 
 # resource "github_branch_protection" "legunto" {
@@ -464,11 +580,20 @@ resource "github_repository" "maintenance" {
   name                 = "maintenance"
   description          = ":wrench: 페미위키 점검 페이지"
   homepage_url         = "https://femiwiki.github.io/maintenance"
-  default_branch       = local.default_repo.default_branch
   has_issues           = local.default_repo.has_issues
   vulnerability_alerts = local.default_repo.vulnerability_alerts
   archive_on_destroy   = local.default_repo.archive_on_destroy
   topics               = ["website"]
+}
+
+resource "github_branch" "maintenance_main" {
+  repository = github_repository.maintenance
+  branch     = "main"
+}
+
+resource "github_branch_default" "maintenance" {
+  repository = github.repository.maintenance
+  branch     = github.branch.maintenance_main
 }
 
 resource "github_branch_protection" "maintenance" {


### PR DESCRIPTION
Blocker: `terraform import` is failed

```
$ terraform import github_branch.infra_main infra:main
Acquiring state lock. This may take a few moments...
github_branch.infra_main: Importing from ID "infra:main"...

Error: Repository infra does not have a branch named main.
$ terraform import github_branch.infra_main femiwiki/infra:main
Acquiring state lock. This may take a few moments...
github_branch.infra_main: Importing from ID "femiwiki/infra:main"...

Error: Repository femiwiki/infra does not have a branch named main.
```

Terraform v0.14.8
provider registry.terraform.io/integrations/github v4.6.0