### PR TITLE
Asia/Seoul로 타임존 설정

### DIFF
--- a/aws/res/bootstrap.sh
+++ b/aws/res/bootstrap.sh
@@ -75,6 +75,12 @@ Defaults secure_path=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bi
 EOF
 
 #
+# 시간대 설정
+#
+TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+#
 # persistent_data EBS 마운트
 #
 sudo mkdir -p /srv


### PR DESCRIPTION
Fixes https://github.com/femiwiki/femiwiki/issues/83

그런데 혹시 이렇게 설정 안 한 데 명시적인 이유가 있나요?