### PR TITLE
aws: set up SES custom Return-Path domain

### DIFF
--- a/aws/route53.tf
+++ b/aws/route53.tf
@@ -66,6 +66,16 @@ resource "aws_route53_record" "femiwiki_com_mx" {
   zone_id = aws_route53_zone.femiwiki_com.zone_id
 }
 
+resource "aws_route53_record" "bounce_femiwiki_com_mx" {
+  name = "bounce.femiwiki.com"
+  records = [
+    "10 feedback-smtp.us-east-1.amazonses.com"
+  ]
+  ttl     = 3600
+  type    = "MX"
+  zone_id = aws_route53_zone.femiwiki_com.zone_id
+}
+
 resource "aws_route53_record" "femiwiki_com_ns" {
   name = "femiwiki.com"
   records = [
@@ -99,6 +109,16 @@ resource "aws_route53_record" "femiwiki_com_txt" {
     "yandex-verification: a457abccca159922",
     # SPF (ref femiwiki/femiwiki#172)
     "v=spf1 include:amazonses.com include:_spf.google.com include:mail.stibee.com ~all",
+  ]
+}
+
+resource "aws_route53_record" "bounce_femiwiki_com_txt" {
+  name    = "bounce.femiwiki.com"
+  ttl     = 900
+  type    = "TXT"
+  zone_id = aws_route53_zone.femiwiki_com.zone_id
+  records = [
+    "v=spf1 include:amazonses.com ~all",
   ]
 }
 

--- a/aws/ses.tf
+++ b/aws/ses.tf
@@ -12,3 +12,10 @@ resource "aws_ses_email_identity" "admin" {
   provider = aws.us
   email    = "admin@femiwiki.com"
 }
+
+# ref femiwiki/femiwiki#365 ("AWS SES Return-Path 도메인 설정")
+resource "aws_ses_domain_mail_from" "femiwiki_com" {
+  provider         = aws.us
+  domain           = aws_ses_domain_identity.femiwiki_com.domain
+  mail_from_domain = "bounce.${aws_ses_domain_identity.femiwiki_com.domain}"
+}


### PR DESCRIPTION
Fixes femiwiki/femiwiki#365. [관련 AWS 문서](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html) ([한국어 (기계 번역)](https://docs.aws.amazon.com/ko_kr/ses/latest/dg/mail-from.html))

- DMARC 스펙에 따르면 SPF 검사를 통과하기 위해서는 이메일의 1) `EHLO/HELO`로 지정된 도메인 또는 2) `MAIL FROM` 도메인과 `From` 도메인이 일치해야 함. [^1] [^2]
- 현재 SES의 `Mail-From` 도메인은 `amazonses.com`이고 `From` 도메인은 `femiwiki.com` 이므로 스펙에 따라 DMARC 오류가 발생함.
- 이 오류를 해결하기 위해 `Return-Path` 도메인을 `femiwiki.com`의 서브도메인 (이 PR에서 `bounce.femiwiki.com`) 으로 지정함.
- 반송 메일을 처리하기 위해 SES에서 반송 도메인을 지정하고, 반송 도메인을 수신할 MX 값과 TXT 값을 설정함
- PS: terraform 라이선스 변경 이후 terraform을 안 써서 `tofu init` 없이도 사용 가능한 `tofu fmt` 말고는 테스트를 해볼수가 없었읍니다... [^3]

[^1]: [RFC 7489](https://datatracker.ietf.org/doc/html/rfc7489) section 3.1.2 `SPF-Authenticated Identifiers`, section 6.3 `aspf`. 우리 DMARC 설정의 경우 `aspf=r` 설정에 따라 서브도메인 가능
[^2]: Return-Path는 이메일이 반송될 경우 해당 주소로 반송하라는 지시.
[^3]: `tofu validate`도 안 먹힘