### PR TITLE
Execute 'nomad setup consul'

### DIFF
--- a/aws/res/nomad.hcl
+++ b/aws/res/nomad.hcl
@@ -32,6 +32,7 @@ plugin "docker" {
 }
 %{ if enable_consul == true }
 consul {
+  enabled = true
   address = "127.0.0.1:8500"
 
   service_identity {

--- a/aws/res/user-data.sh
+++ b/aws/res/user-data.sh
@@ -272,4 +272,6 @@ NOMAD_TOKEN="$(echo "$NOMAD_ACL_BOOTSTRAP" | grep 'Secret ID' | rev | cut -d' ' 
 
 # Write NOMAD_TOKEN as a local file
 echo "NOMAD_TOKEN=$NOMAD_TOKEN" >> "/etc/environment"
+
+nomad setup consul -y
 %{ endif }


### PR DESCRIPTION
The command is the simplest way to try out the new integration to Consul, but provides the least customization.[^1]

Related to #274

[^1]: https://www.hashicorp.com/blog/nomad-1-7-improves-vault-and-consul-integrations-adds-numa-support