### PR TITLE
aws: Export Nomad and Consul tokens in the user data

### DIFF
--- a/aws/res/user-data.sh
+++ b/aws/res/user-data.sh
@@ -252,7 +252,8 @@ until consul members > /dev/null; do
 CONSUL_ACL_BOOTSTRAP="$(consul acl bootstrap)"
 
 CONSUL_ACCESSOR_ID="$(echo "$CONSUL_ACL_BOOTSTRAP" | grep AccessorID | rev | cut -d' ' -f1 | rev)"
-CONSUL_TOKEN="$(echo "$CONSUL_ACL_BOOTSTRAP" | grep SecretID | rev | cut -d' ' -f1 | rev)"
+CONSUL_HTTP_TOKEN="$(echo "$CONSUL_ACL_BOOTSTRAP" | grep SecretID | rev | cut -d' ' -f1 | rev)"
+export CONSUL_HTTP_TOKEN
 
 # Write CONSUL_TOKEN as a local file
 echo "CONSUL_HTTP_TOKEN=$CONSUL_TOKEN" >> "/etc/environment"
@@ -269,6 +270,7 @@ NOMAD_ACL_BOOTSTRAP="$(nomad acl bootstrap)"
 
 NOMAD_ACCESSOR_ID="$(echo "$NOMAD_ACL_BOOTSTRAP" | grep 'Accessor ID' | rev | cut -d' ' -f1 | rev)"
 NOMAD_TOKEN="$(echo "$NOMAD_ACL_BOOTSTRAP" | grep 'Secret ID' | rev | cut -d' ' -f1 | rev)"
+export NOMAD_TOKEN
 
 # Write NOMAD_TOKEN as a local file
 echo "NOMAD_TOKEN=$NOMAD_TOKEN" >> "/etc/environment"


### PR DESCRIPTION
Resolves the next error:

```
[✘] Could not create Consul auth method: Unexpected response code: 403 (Permission denied: anonymous token lacks permission 'acl:write'. The anonymous token is used implicitly when a request does not specify a token.)
2024-10-03 07:45:23,839 - cc_scripts_user.py[WARNING]: Failed to run module scripts-user (scripts in /var/lib/cloud/instance/scripts)
2024-10-03 07:45:23,840 - util.py[WARNING]: Running module scripts-user (<module 'cloudinit.config.cc_scripts_user' from '/usr/lib/python3.9/site-packages/cloudinit/config/cc_scripts_user.py'>) failed
```