### PR TITLE
aws: Resize the Amazon EBS volume to 16G

### DIFF
--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -159,7 +159,7 @@ resource "aws_instance" "femiwiki_green" {
 
   root_block_device {
     delete_on_termination = true
-    volume_size           = 8
+    volume_size           = 16
     volume_type           = "gp3"
   }
 


### PR DESCRIPTION
`docker pull` failed because of the disk