### PR TITLE
github: Relax quibble-action review, require status checks

### DIFF
--- a/github/repo.tf
+++ b/github/repo.tf
@@ -173,6 +173,17 @@ module "quibble_action" {
   ]
 
   required_pull_request_reviews = []
+  required_status_checks_contexts = [
+    [
+      "zizmor",
+      "semantic-pull-request",
+      "yamllint",
+      "ruff",
+      "actionlint",
+      "biome",
+      "rumdl",
+    ]
+  ]
 }
 
 import {

--- a/github/repo.tf
+++ b/github/repo.tf
@@ -171,6 +171,8 @@ module "quibble_action" {
     "mediawiki",
     "github-actions",
   ]
+
+  required_pull_request_reviews = []
 }
 
 import {


### PR DESCRIPTION
## Summary
- Drop the required approving review on `quibble-action` (`required_pull_request_reviews = []`).
- Require the existing PR checks (`zizmor`, `semantic-pull-request`) plus the linter jobs added in femiwiki/quibble-action#11 (`yamllint`, `ruff`, `actionlint`, `biome`, `rumdl`).
- Auto-merge is already enabled repository-wide via `allow_auto_merge = true` in the module.

## Notes
- femiwiki/quibble-action#11 is already merged, so all the required checks now exist.
- `linter.yaml` triggers on `push`, so its checks appear on same-repo branch PRs. They do not run for fork PRs, so such PRs could be blocked by the required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)