### PR TITLE
github: Grant Reviewer team write access for CODEOWNERS

### DIFF
--- a/github/modules/github-repository/main.tf
+++ b/github/modules/github-repository/main.tf
@@ -55,6 +55,10 @@ resource "github_branch_protection" "branch_protection" {
 resource "github_team_repository" "team_repository" {
   repository = github_repository.repository.name
   team_id    = "3688706"
+  # Write access so the Reviewer team can be used as a code owner in CODEOWNERS.
+  # Without an explicit permission the provider defaults to "pull" (read), which
+  # makes GitHub reject the team in CODEOWNERS ("does not have write access").
+  permission = "push"
 }
 
 # Give push access to @translatewiki https://github.com/femiwiki/femiwiki/issues/91

--- a/github/modules/github-repository/main.tf
+++ b/github/modules/github-repository/main.tf
@@ -55,9 +55,7 @@ resource "github_branch_protection" "branch_protection" {
 resource "github_team_repository" "team_repository" {
   repository = github_repository.repository.name
   team_id    = "3688706"
-  # Write access so the Reviewer team can be used as a code owner in CODEOWNERS.
-  # Without an explicit permission the provider defaults to "pull" (read), which
-  # makes GitHub reject the team in CODEOWNERS ("does not have write access").
+  # "pull" (defaults) makes GitHub reject the team in CODEOWNERS
   permission = "push"
 }
 


### PR DESCRIPTION
## Problem

`femiwiki/quibble-action` added a `CODEOWNERS` with `* @femiwiki/reviewer`, but GitHub reports:

> Unknown owner on line 1: make sure the team @femiwiki/reviewer exists, is publicly visible, and has write access to the repository

The team **exists** and is **visible** (`privacy = "closed"`). The failing requirement is **write access**: the Reviewer team only has `pull` (read).

## Cause

The `github-repository` module grants the Reviewer team (id `3688706`) access to every repo:

```hcl
resource "github_team_repository" "team_repository" {
  repository = github_repository.repository.name
  team_id    = "3688706"
}
```

`permission` is unset, so the `integrations/github` provider defaults to `"pull"`. A read-only team can't be a code owner.

## Fix

Set `permission = "push"` on that resource.

## Blast radius

This module backs **all** femiwiki repos, so the Reviewer team gains **write access org-wide**. That matches the team's purpose (reviewing PRs / being a code owner). If narrower scoping is wanted, this would instead need a per-repo variable, let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)