### PR TITLE
Fix English typos in comments and descriptions

### DIFF
--- a/aws/res/user-data-mysql.sh.tftpl
+++ b/aws/res/user-data-mysql.sh.tftpl
@@ -127,7 +127,7 @@ if ! file -s /dev/nvme1n1 | grep -q "filesystem data"; then
     TEMP_PASSWORD="$(journalctl -u mysqld.service --since='30 seconds ago' 2>/dev/null | grep 'temporary password' | awk '{print $NF}')"
     if [ -n "$TEMP_PASSWORD" ]; then
       echo "Temporary password found: $TEMP_PASSWORD"
-      # TODO Save it to the ssm paramater store
+      # TODO Save it to the ssm parameter store
       break
     fi
     CURRENT_TIME=$(date +%s)

--- a/github/repo.tf
+++ b/github/repo.tf
@@ -105,7 +105,7 @@ module "tweetbot" {
 module "remote_gadgets" {
   source      = "./modules/github-repository"
   name        = "remote-gadgets"
-  description = "📽️ External repository for Javascript/CSS on FemiWiki"
+  description = "📽️ External repository for JavaScript/CSS on Femiwiki"
   topics = [
     "bot",
   ]

--- a/github/team.tf
+++ b/github/team.tf
@@ -1,6 +1,6 @@
 resource "github_team" "reviewer" {
   name        = "Reviewer"
-  description = "People reviwing PRs"
+  description = "People reviewing PRs"
   privacy     = "closed"
 }
 


### PR DESCRIPTION
## Summary
Proofread the English in comments and `description` fields across the repository. Korean comments were left untouched. Three clear fixes:

- `github/team.tf`: `reviwing` → `reviewing`
- `aws/res/user-data-mysql.sh.tftpl`: `paramater` → `parameter`
- `github/repo.tf`: `Javascript` → `JavaScript`, and `FemiWiki` → `Femiwiki` for consistency with every other usage in the repo

These are string/comment-only changes with no behavioral impact (the `remote-gadgets` repository `description` will update on the next `terraform apply`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)