### PR TITLE
github: don't require branches up to date before merging

### DIFF
--- a/github/modules/github-repository/main.tf
+++ b/github/modules/github-repository/main.tf
@@ -37,7 +37,7 @@ resource "github_branch_protection" "branch_protection" {
   dynamic "required_status_checks" {
     for_each = var.required_status_checks_contexts
     content {
-      strict   = true
+      strict   = false
       contexts = required_status_checks.value
     }
   }


### PR DESCRIPTION
## What

Set `required_status_checks.strict = false` in the `github-repository` module (one line). This drops GitHub's "Require branches to be up to date before merging" for every repo that uses the module (FemiwikiSkin, UnifiedExtensionForFemiwiki, CrawlingBlocker, infra, nomad).

## Why

With `strict = true`, every queued PR must be rebased onto the latest `main` and re-run the **full test matrix** whenever `main` moves. With an active Dependabot queue this serialises merges into a slow rebase-and-rerun grind (merge one → all others go out of date → rebase each → wait CI → repeat).

## Risk (low, and bounded)

`strict` only governs *out-of-date* branches, not conflicts:

- **Textual conflicts still block** — two PRs touching the same `package-lock.json` are still unmergeable until rebased, so this is not "merge anything".
- The only new exposure is a **logical** conflict: a PR that passed CI against an older `main` could break `main` once merged (e.g. one PR removes a symbol another still uses). For dependency bumps this is rare.
- `main`'s own push CI runs on every merge, so such a breakage is caught immediately after the merge rather than prevented before it.

The fully-safe alternative that also avoids the grind is a **merge queue** (re-tests PRs in order automatically), which is more setup; `strict = false` is the lightweight trade-off.

## Note

Applying this (`terraform apply`) is what actually changes the branch protection on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)