### PR TITLE
github: stop requiring reviews on the femiwiki repo

### DIFF
--- a/github/repo.tf
+++ b/github/repo.tf
@@ -42,6 +42,9 @@ module "femiwiki" {
   name         = "femiwiki"
   description  = ":earth_asia: 문서화된 페미위키 기술 정보 및 이슈 트래킹 정보 제공"
   homepage_url = "https://femiwiki.com"
+  # Documentation-only repo; the module default of one required review is
+  # overkill and just blocks doc PRs. Disable it like the other repos.
+  required_pull_request_reviews = local.default_repo.required_pull_request_reviews
   topics = [
     "feminism",
     "wiki",

--- a/github/repo.tf
+++ b/github/repo.tf
@@ -42,8 +42,6 @@ module "femiwiki" {
   name         = "femiwiki"
   description  = ":earth_asia: 문서화된 페미위키 기술 정보 및 이슈 트래킹 정보 제공"
   homepage_url = "https://femiwiki.com"
-  # Documentation-only repo; the module default of one required review is
-  # overkill and just blocks doc PRs. Disable it like the other repos.
   required_pull_request_reviews = local.default_repo.required_pull_request_reviews
   topics = [
     "feminism",


### PR DESCRIPTION
## Why
The `femiwiki` repo is documentation-only (process docs, CHANGELOG, the Korean frontend guide, an empty README; no app/deploy code). But `module "femiwiki"` does not override `required_pull_request_reviews`, so it inherits the module default of **1 required approving review**, which blocks doc PRs given how few reviewers there are. Every other active repo (infra, docker-mediawiki, bots) already sets it to `[]`.

## Change
Pass `required_pull_request_reviews = local.default_repo.required_pull_request_reviews` (i.e. `[]`) to `module "femiwiki"`.

## Apply note
This repo has no CI/CD, so it only takes effect after a manual `terraform apply`. After applying, the femiwiki repo no longer requires a review (e.g. femiwiki#434 becomes mergeable normally).