### PR TITLE
github: remove the retired nomad repo and its labels

### DIFF
--- a/github/label.tf
+++ b/github/label.tf
@@ -346,7 +346,6 @@ locals {
       ]
     )
 
-    nomad       = concat(local.base_label_suite, ["cd", "disruption", "consul", "restbase"])
     ".github"   = concat(local.base_label_suite, ["ci"])
     sns-discord = local.base_label_suite
 

--- a/github/repo.tf
+++ b/github/repo.tf
@@ -25,18 +25,6 @@ module "infra" {
   ]
 }
 
-module "nomad" {
-  source                          = "./modules/github-repository"
-  name                            = "nomad"
-  description                     = ":whale: Femiwiki nomad"
-  enforce_admins                  = local.with_cd.enforce_admins
-  required_pull_request_reviews   = local.with_cd.required_pull_request_reviews
-  required_status_checks_contexts = [["before-cd-test"]]
-  topics = [
-    "nomad",
-  ]
-}
-
 module "femiwiki" {
   source       = "./modules/github-repository"
   name         = "femiwiki"


### PR DESCRIPTION
## Why
Nomad is no longer used (production runs on EC2 + the Terraform docker provider), so stop managing `femiwiki/nomad`.

## ⚠️ Archives, does not delete
The `github-repository` module sets `archive_on_destroy = true`, so apply **archives** `femiwiki/nomad` (read-only, fully preserved), not deletes. Please confirm in the TFC speculative plan that `module.nomad...github_repository.repository` is destroy-as-archive before merging.

## Changes
- Remove `module "nomad"` from `github/repo.tf` (archives the repo).
- Remove the `nomad` label suite from `github/label.tf`.

## Already done out-of-band
The `nomad` issue labels were removed from state with `terraform state rm 'github_issue_label.femiwiki["nomad.*"]'` (10 instances) because `github_issue_label.femiwiki` has `lifecycle.prevent_destroy = true` and could not be destroyed by apply. With them out of state, dropping the `nomad =` map entry keeps config and state in sync (no recreate, no destroy). The labels remain on the now-archived repo on GitHub, untouched.

## Expected plan
Only `module.nomad.*` destroyed (repo archived; its branch/protection/team associations removed). No `github_issue_label` changes.