### PR TITLE
docker: stop loading FemiwikiCrawlingBlocker in Hotfix.php (deploy-coupled)

### DIFF
--- a/docker/res/Hotfix.php
+++ b/docker/res/Hotfix.php
@@ -23,10 +23,6 @@ $wgSpecialPageLockdown = [
 	'Log' => [ 'user' ],
 ];
 
-// FemiwikiCrawlingBlocker
-wfLoadExtension( 'FemiwikiCrawlingBlocker' );
-$wgFemiwikiCrawlingBlockerEnabled = false;
-
 foreach ( [
 	NS_TALK,
 	NS_USER_TALK,


### PR DESCRIPTION
## ⚠️ DRAFT — deploy-coupled, do not apply alone

## Finding
`infra/docker/res/Hotfix.php` is injected into prod via `MEDIAWIKI_HOTFIX_SNIPPET = file("res/Hotfix.php")` (container.tf). It contained:
```php
wfLoadExtension( 'FemiwikiCrawlingBlocker' );
$wgFemiwikiCrawlingBlockerEnabled = false;
```
This is why FemiwikiCrawlingBlocker was effectively unused in prod (the hotfix forced it disabled, overriding LocalSettings' `true`).

## Why this is needed
docker-mediawiki#1017 removes FemiwikiCrawlingBlocker from the image. Once that image deploys, this `wfLoadExtension` would **fatal** (extension not installed).

## ⚠️ Ordering
Apply this **only together with the new femiwiki image** that lacks FemiwikiCrawlingBlocker (i.e. in the same `infra/docker` apply that bumps `container.tf` to the post-#1017 image tag):
- Apply alone (old image still deployed) → LocalSettings re-enables the extension (no hotfix override) → behavior change.
- New image without this change → fatal on load.

Recommend folding this into the production-deploy PR that bumps the femiwiki image tag in `container.tf`, so they apply atomically. Kept as draft to avoid a standalone apply.

## Note (separate, non-fatal)
Hotfix.php also sets `$wgUnifiedExtensionForFemiwikiRelatedArticlesUseLinks = false`, but UnifiedExtension v5.0.0 dropped the related-articles tweak (#185). That config is now dead (harmless, not fatal) and could be cleaned up later.