### PR TITLE
app: zero-downtime Step 2/3 infra — ASG + reconciler (DRAFT, not applied)

### DIFF
--- a/aws/app-iam.tf
+++ b/aws/app-iam.tf
@@ -1,0 +1,143 @@
+#
+# IAM for the backend ASG nodes and for the edge reconciler.
+#
+# Shared identifiers (account id resolved at plan time; region is pinned for the
+# whole workspace in base.tf). Using the ASG NAME (not the resource attribute) in
+# the lifecycle ARN avoids a role -> profile -> launch_template -> ASG -> role cycle.
+#
+data "aws_caller_identity" "current" {}
+
+locals {
+  region           = "ap-northeast-1"
+  app_asg_name     = "femiwiki-app"
+  app_asg_arn_glob = "arn:aws:autoscaling:${local.region}:${data.aws_caller_identity.current.account_id}:autoScalingGroup:*:autoScalingGroupName/${local.app_asg_name}"
+}
+
+#
+# Backend ASG node role + instance profile (none existed before).
+# Reuses the same EC2 assume-role policy as aws_iam_role.femiwiki / .database.
+#
+resource "aws_iam_role" "app" {
+  name               = "App"
+  description        = "Femiwiki backend ASG nodes (FrankenPHP)"
+  assume_role_policy = data.aws_iam_policy_document.instance_assume_role.json
+}
+
+resource "aws_iam_instance_profile" "app" {
+  name = "App"
+  role = aws_iam_role.app.name
+}
+
+# Runtime secret fetch (replaces the edge's plan-time data.aws_ssm_parameters_by_path
+# + docker env injection). The node calls `aws ssm get-parameter --with-decryption`
+# at boot for exactly the /mediawiki/* and /mysql/* keys used in docker/container.tf,
+# plus the new /alloy/* creds (app-ssm.tf).
+data "aws_iam_policy_document" "app_node" {
+  statement {
+    sid = "SsmGetAppSecrets"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath",
+    ]
+    resources = [
+      "arn:aws:ssm:${local.region}:${data.aws_caller_identity.current.account_id}:parameter/mediawiki/*",
+      "arn:aws:ssm:${local.region}:${data.aws_caller_identity.current.account_id}:parameter/mysql/*",
+      "arn:aws:ssm:${local.region}:${data.aws_caller_identity.current.account_id}:parameter/alloy/*",
+    ]
+  }
+
+  # Only needed if any of the above are SecureString (site_key / passwords are).
+  # Scoped to SSM's use of KMS so it cannot decrypt arbitrary ciphertext.
+  statement {
+    sid       = "KmsDecryptViaSsm"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${local.region}.amazonaws.com"]
+    }
+  }
+
+  # Self-signalling for the LAUNCHING lifecycle hook (the health gate) and the
+  # container watchdog (SetInstanceHealth Unhealthy -> ASG replaces the node).
+  statement {
+    sid = "LifecycleSelfSignal"
+    actions = [
+      "autoscaling:CompleteLifecycleAction",
+      "autoscaling:RecordLifecycleActionHeartbeat",
+      "autoscaling:SetInstanceHealth",
+    ]
+    resources = [local.app_asg_arn_glob]
+  }
+}
+
+resource "aws_iam_policy" "app_node" {
+  name        = "AppNode"
+  description = "SSM secret fetch + self lifecycle signalling for backend ASG nodes"
+  policy      = data.aws_iam_policy_document.app_node.json
+}
+
+resource "aws_iam_role_policy_attachment" "app_node" {
+  role       = aws_iam_role.app.name
+  policy_arn = aws_iam_policy.app_node.arn
+}
+
+# MediaWiki S3 upload backend (same policy the edge fastcgi used).
+resource "aws_iam_role_policy_attachment" "app_amazon_s3_access" {
+  role       = aws_iam_role.app.name
+  policy_arn = aws_iam_policy.amazon_s3_access.arn
+}
+
+# Session Manager shell + CloudWatch agent (parity with the other roles).
+# Deliberately NOT attached: route53, access_caddycerts, download_secrets,
+# upload_backup (no TLS/Caddy/backup/S3-secrets role on the backend).
+resource "aws_iam_role_policy_attachment" "app_managed_policies" {
+  for_each = toset([
+    "AmazonSSMManagedInstanceCore",
+    "CloudWatchAgentServerPolicy",
+  ])
+  role       = aws_iam_role.app.name
+  policy_arn = "arn:aws:iam::aws:policy/${each.key}"
+}
+
+#
+# Reconciler permissions, attached to the EXISTING edge role (aws_iam_role.femiwiki).
+# The edge daemon resolves InService+Healthy ASG instances -> private IPs (Caddy
+# upstreams) and completes/drains the TERMINATING hook. Describe* has no
+# resource-level support (Resource "*"); the write actions are scoped to the ASG.
+#
+data "aws_iam_policy_document" "reconciler" {
+  statement {
+    sid = "DescribeFleet"
+    actions = [
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeLifecycleHooks",
+      "ec2:DescribeInstances",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "DrainAndGate"
+    actions = [
+      "autoscaling:CompleteLifecycleAction",
+      "autoscaling:RecordLifecycleActionHeartbeat",
+      "autoscaling:SetInstanceHealth",
+    ]
+    resources = [local.app_asg_arn_glob]
+  }
+}
+
+resource "aws_iam_policy" "reconciler" {
+  name        = "Reconciler"
+  description = "Edge reconciler: read ASG fleet, drain/gate the terminate hook"
+  policy      = data.aws_iam_policy_document.reconciler.json
+}
+
+resource "aws_iam_role_policy_attachment" "femiwiki_reconciler" {
+  role       = aws_iam_role.femiwiki.name
+  policy_arn = aws_iam_policy.reconciler.arn
+}

--- a/aws/app-reconciler.tf
+++ b/aws/app-reconciler.tf
@@ -1,0 +1,134 @@
+#
+# Edge reconciler delivery + event wiring + alarms.
+#
+# The edge (aws_instance.docker) is a pet with lifecycle { ignore_changes=[user_data] }
+# (ec2.tf), so a user-data edit will NOT update the live box. The script + units are
+# delivered Terraform-managed and self-healing via SSM Run Command (the edge already has
+# AmazonSSMManagedInstanceCore). region comes from local.region (app-iam.tf); we avoid
+# data.aws_region (its `.name` is deprecated in aws ~> 6.x).
+#
+
+# --- deliver script + env + units to the edge, idempotently, on a schedule ---
+resource "aws_ssm_document" "reconciler_install" {
+  name            = "FemiwikiReconcilerInstall"
+  document_type   = "Command"
+  document_format = "YAML"
+  content = yamlencode({
+    schemaVersion = "2.2"
+    description   = "Install/refresh the Femiwiki edge reconciler"
+    mainSteps = [{
+      action = "aws:runShellScript"
+      name   = "install"
+      inputs = {
+        runCommand = [
+          templatefile("${path.module}/res/install-reconciler.sh.tftpl", {
+            reconciler_sh   = file("${path.module}/res/femiwiki-reconciler.sh")
+            reconciler_env  = file("${path.module}/res/femiwiki-reconciler.env")
+            unit_service    = file("${path.module}/res/femiwiki-reconciler.service")
+            unit_timer      = file("${path.module}/res/femiwiki-reconciler.timer")
+            unit_caddywatch = file("${path.module}/res/femiwiki-reconciler-caddywatch.service")
+          })
+        ]
+      }
+    }]
+  })
+}
+
+resource "aws_ssm_association" "reconciler_install" {
+  name                = aws_ssm_document.reconciler_install.name
+  schedule_expression = "rate(30 minutes)" # self-heal drift; first run is immediate on create
+  targets {
+    key    = "tag:Name"
+    values = ["docker"] # the edge instance (aws_instance.docker, tags.Name="docker")
+  }
+}
+
+# --- alarms (the load-bearing path; reconciler also ships a node_exporter textfile) ---
+resource "aws_cloudwatch_metric_alarm" "reconciler_upstreams_low" {
+  alarm_name          = "Femiwiki reconciler upstream_count < 1"
+  namespace           = "Femiwiki/Reconciler"
+  metric_name         = "UpstreamCount"
+  statistic           = "Minimum"
+  period              = 60
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  threshold           = 1
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching" # no data == blind == bad
+  alarm_actions       = [aws_sns_topic.cloudwatch_alarms_topic.arn]
+  ok_actions          = [aws_sns_topic.cloudwatch_alarms_topic.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "reconciler_stale" {
+  alarm_name          = "Femiwiki reconciler stale (no successful pass)"
+  namespace           = "Femiwiki/Reconciler"
+  metric_name         = "ReconcilerHeartbeat"
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  threshold           = 1
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+  alarm_actions       = [aws_sns_topic.cloudwatch_alarms_topic.arn]
+  ok_actions          = [aws_sns_topic.cloudwatch_alarms_topic.arn]
+}
+
+# --- EventBridge kick: ASG lifecycle transition -> SSM Run Command on the edge (no Lambda) ---
+resource "aws_cloudwatch_event_rule" "asg_lifecycle" {
+  name        = "femiwiki-asg-lifecycle-reconcile"
+  description = "Kick the edge reconciler on ASG launch/terminate lifecycle actions"
+  event_pattern = jsonencode({
+    source      = ["aws.autoscaling"]
+    detail-type = ["EC2 Instance-launch Lifecycle Action", "EC2 Instance-terminate Lifecycle Action"]
+    detail      = { AutoScalingGroupName = [aws_autoscaling_group.app.name] }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "kick_reconciler" {
+  rule     = aws_cloudwatch_event_rule.asg_lifecycle.name
+  arn      = "arn:aws:ssm:${local.region}::document/AWS-RunShellScript"
+  role_arn = aws_iam_role.eventbridge_ssm.arn
+  run_command_targets {
+    key    = "tag:Name"
+    values = ["docker"]
+  }
+  input = jsonencode({ commands = ["systemctl start --no-block femiwiki-reconciler.service"] })
+}
+
+resource "aws_iam_role" "eventbridge_ssm" {
+  name               = "femiwiki-eventbridge-ssm-runcommand"
+  assume_role_policy = data.aws_iam_policy_document.eventbridge_assume.json
+}
+
+data "aws_iam_policy_document" "eventbridge_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "eventbridge_ssm" {
+  name   = "send-runshellscript-to-edge"
+  role   = aws_iam_role.eventbridge_ssm.id
+  policy = data.aws_iam_policy_document.eventbridge_ssm.json
+}
+
+data "aws_iam_policy_document" "eventbridge_ssm" {
+  statement {
+    actions   = ["ssm:SendCommand"]
+    resources = ["arn:aws:ssm:${local.region}::document/AWS-RunShellScript"]
+  }
+  statement {
+    actions   = ["ssm:SendCommand"]
+    resources = ["arn:aws:ec2:${local.region}:${data.aws_caller_identity.current.account_id}:instance/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "ssm:resourceTag/Name"
+      values   = ["docker"]
+    }
+  }
+}

--- a/aws/app-sg.tf
+++ b/aws/app-sg.tf
@@ -1,0 +1,53 @@
+#
+# Backend ASG security group (FrankenPHP serving nodes)
+#
+# The backend is reachable ONLY from the edge SG (aws_security_group.femiwiki):
+# the edge Caddy reverse_proxy + its active /healthz-ready checks dial :8080.
+# No world ingress, no 80/443 on the backend. DB access is granted by ALSO
+# attaching the pre-existing aws_security_group.mediawiki to the launch template
+# (the mysql_ingress_mediawiki rule in sg.tf already covers 3306 from that SG).
+#
+resource "aws_security_group" "app" {
+  name        = "app"
+  description = "Femiwiki backend ASG nodes (FrankenPHP, plain HTTP :8080)"
+  vpc_id      = aws_default_vpc.default.id
+
+  tags = {
+    Name = "App"
+  }
+}
+
+resource "aws_security_group_rule" "app_ingress_http_from_edge" {
+  security_group_id        = aws_security_group.app.id
+  description              = "FrankenPHP :8080 from the edge Caddy only"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 8080
+  to_port                  = 8080
+  source_security_group_id = aws_security_group.femiwiki.id
+}
+
+resource "aws_security_group_rule" "app_egress" {
+  security_group_id = aws_security_group.app.id
+  description       = "all egress (SSM, S3, SES, Grafana Cloud, image pull)"
+  type              = "egress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+}
+
+#
+# Edge SG additions: the shared memcached lives on the edge (network_mode=host).
+# memcached has no auth, so it must be reachable from the app SG ONLY, never world.
+#
+resource "aws_security_group_rule" "femiwiki_ingress_memcached_from_app" {
+  security_group_id        = aws_security_group.femiwiki.id
+  description              = "memcached from backend ASG nodes only"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 11211
+  to_port                  = 11211
+  source_security_group_id = aws_security_group.app.id
+}

--- a/aws/app-ssm.tf
+++ b/aws/app-ssm.tf
@@ -1,0 +1,22 @@
+#
+# Alloy (Grafana Cloud) credentials for the ASG nodes.
+#
+# The EDGE bakes these into user-data from var.prometheus_password / var.loki_password
+# at plan time (ec2.tf:74). ASG user-data is re-rendered on every instance refresh and
+# is readable by anything on the box, so the backend fetches the creds from SSM at boot
+# instead of baking them. The non-secret Alloy fields (endpoints, usernames) stay
+# templated in res/config.alloy.tftpl; only the two passwords come from here.
+#
+resource "aws_ssm_parameter" "alloy_prometheus_password" {
+  name        = "/alloy/prometheus_password"
+  description = "Grafana Cloud Prometheus remote_write password (ASG nodes)"
+  type        = "SecureString"
+  value       = var.prometheus_password
+}
+
+resource "aws_ssm_parameter" "alloy_loki_password" {
+  name        = "/alloy/loki_password"
+  description = "Grafana Cloud Loki push password (ASG nodes)"
+  type        = "SecureString"
+  value       = var.loki_password
+}

--- a/aws/app.tf
+++ b/aws/app.tf
@@ -1,0 +1,219 @@
+#
+# Backend tier: a small ASG of the FrankenPHP image (desired=1, transient 2 during
+# a deploy), t4g.small ARM, AZ ap-northeast-1a, plain HTTP :8080, reachable only
+# from the edge SG. Zero-downtime deploys = launch-before-terminate instance refresh
+# gated on a real /healthz-ready via the LAUNCHING lifecycle hook.
+#
+
+variable "app_image" {
+  type        = string
+  description = "FrankenPHP backend image:tag. THIS is the deploy lever: bump it -> new launch template version -> auto instance refresh. Pin by digest in production."
+  default     = "ghcr.io/femiwiki/femiwiki-frankenphp:2026-06-28"
+}
+
+variable "app_frankenphp_num_threads" {
+  type        = number
+  description = "FrankenPHP classic-mode fixed thread pool. RAM: threads*128M + 512M opcache must fit the t4g.small (2GB) -> keep <= ~8. DB: nodes*threads*connects_per_request must stay under MariaDB max_connections."
+  default     = 8
+}
+
+variable "app_cpu_credits" {
+  type        = string
+  description = "t4g credit mode. 'unlimited' avoids CPU-throttle brownouts on the single serving node (matches edge/db); 'standard' is cheaper but can throttle under sustained load."
+  default     = "unlimited"
+}
+
+locals {
+  launch_hook_name    = "femiwiki-app-launch"
+  terminate_hook_name = "femiwiki-app-terminate"
+}
+
+#
+# (1) Launch template: t4g.small arm64, the backend SG + the DB-client SG, IMDSv2
+#     with instance tags exposed, and the self-health-gating user-data.
+#
+resource "aws_launch_template" "app" {
+  name_prefix            = "femiwiki-app-"
+  description            = "Femiwiki FrankenPHP backend node"
+  image_id               = data.aws_ami.amazon_linux_2_arm64.image_id # AL2023 minimal arm64 host; runs Docker
+  instance_type          = "t4g.small"
+  ebs_optimized          = true
+  update_default_version = true
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.app.arn
+  }
+
+  # Backend SG (ingress 8080 from the edge only, egress all) + the DB-client SG
+  # (grants 3306 to the DB via the existing mysql_ingress_mediawiki rule). No EIP/NAT:
+  # the node needs a public IP to reach SSM/S3/SES/Grafana Cloud/GHCR. We assign it
+  # EXPLICITLY here rather than relying on the (unmanaged) default-subnet
+  # map_public_ip_on_launch, so egress cannot silently break if that attribute flips.
+  # SGs move into this block: vpc_security_group_ids cannot coexist with
+  # network_interfaces on the same launch template.
+  network_interfaces {
+    device_index                = 0
+    associate_public_ip_address = true
+    delete_on_termination       = true
+    security_groups = [
+      aws_security_group.app.id,
+      aws_security_group.mediawiki.id,
+    ]
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required" # IMDSv2 only
+    instance_metadata_tags      = "enabled"  # exposes aws:autoscaling:groupName to user-data
+    http_put_response_hop_limit = 2          # docker container -> IMDS (host net is hop 1; bridge would be 2)
+  }
+
+  credit_specification {
+    cpu_credits = var.app_cpu_credits
+  }
+
+  monitoring {
+    enabled = false
+  }
+
+  block_device_mappings {
+    device_name = "/dev/xvda" # AL2023 root device
+    ebs {
+      volume_size           = 30
+      volume_type           = "gp3"
+      delete_on_termination = true
+      encrypted             = true
+    }
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags          = { Name = "femiwiki-app" }
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags          = { Name = "femiwiki-app" }
+  }
+
+  user_data = base64encode(templatefile("${path.module}/res/user-data-app.sh.tftpl", {
+    image                  = var.app_image
+    region                 = local.region
+    frankenphp_num_threads = var.app_frankenphp_num_threads
+    launch_hook_name       = local.launch_hook_name
+    mysql_endpoint         = "${aws_instance.database.private_ip}:3306"
+    edge_private_ip        = aws_instance.docker.private_ip
+    mediawiki_server       = "https://femiwiki.com"
+    hotfix_snippet         = file("${path.module}/res/Hotfix.php")
+
+    # Non-secret Alloy fields stay templated; the two passwords are sentinels that
+    # the node substitutes at boot from SSM (app-ssm.tf). Same body as the edge.
+    alloy_config = templatefile("${path.module}/res/config.alloy.tftpl", {
+      name                = "app"
+      prometheus_endpoint = "https://prometheus-prod-49-prod-ap-northeast-0.grafana.net/api/prom/push"
+      prometheus_username = "1835631"
+      prometheus_password = "@@PROMETHEUS_PASSWORD@@"
+      loki_endpoint       = "https://logs-prod-030.grafana.net/loki/api/v1/push"
+      loki_username       = "1017101"
+      loki_password       = "@@LOKI_PASSWORD@@"
+    })
+  }))
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = { Name = "femiwiki-app" }
+}
+
+#
+# (2) Auto Scaling group: desired=1/min=1/max=2 (room for the deploy surge), AZ-a,
+#     EC2 health checks (no ELB), launch-before-terminate maintenance policy, and the
+#     launch + terminate lifecycle hooks.
+#
+resource "aws_autoscaling_group" "app" {
+  name                = local.app_asg_name
+  min_size            = 1
+  max_size            = 2 # desired(1) + 1 surge for max_healthy_percentage=200
+  desired_capacity    = 1
+  vpc_zone_identifier = [aws_default_subnet.default["a"].id] # single AZ 1a, same as the DB
+
+  # No ELB/ALB/NLB in this architecture: ASG only watches EC2 status checks. App
+  # health is enforced elsewhere (launch hook gate + edge Caddy active checks +
+  # the node watchdog's SetInstanceHealth).
+  health_check_type         = "EC2"
+  health_check_grace_period = 120
+  default_instance_warmup   = 120
+  wait_for_capacity_timeout = "15m" # the launch hook delays InService until /healthz-ready passes
+  capacity_rebalance        = false
+
+  launch_template {
+    id = aws_launch_template.app.id
+    # latest_version (the resource ATTRIBUTE, an integer) -> a tag bump produces a new
+    # LT version, Terraform sees the integer change, the ASG updates, and the refresh
+    # fires. Do NOT use the literal "$Latest": a refresh does not start with "$Latest".
+    version = aws_launch_template.app.latest_version
+  }
+
+  # Launch-before-terminate: keep 100% healthy at all times, allow surging to 200%
+  # so the new node is InService+healthy BEFORE the old one is terminated.
+  instance_maintenance_policy {
+    min_healthy_percentage = 100
+    max_healthy_percentage = 200
+  }
+
+  # LAUNCHING gate: the instance sits in Pending:Wait until user-data confirms a real
+  # /healthz-ready (then complete-lifecycle-action CONTINUE). If it never gets healthy
+  # within the heartbeat, DefaultResult=ABANDON terminates it and auto_rollback reverts.
+  # heartbeat_timeout covers image pull + boot + first ready; user-data also extends it
+  # with record-lifecycle-action-heartbeat.
+  initial_lifecycle_hook {
+    name                 = local.launch_hook_name
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+    default_result       = "ABANDON"
+    heartbeat_timeout    = 600
+  }
+
+  # TERMINATING drain: the instance sits in Terminating:Wait so the EDGE reconciler can
+  # remove it from the Caddy upstreams (add-before-remove) and confirm drain, then call
+  # complete-lifecycle-action CONTINUE. DefaultResult=CONTINUE so a reconciler outage
+  # cannot wedge a termination; heartbeat_timeout >= reconciler convergence + drain.
+  initial_lifecycle_hook {
+    name                 = local.terminate_hook_name
+    lifecycle_transition = "autoscaling:EC2_INSTANCE_TERMINATING"
+    default_result       = "CONTINUE"
+    heartbeat_timeout    = 180
+  }
+
+  # (3) A launch-template change always triggers a Rolling refresh, so no explicit `triggers`
+  #     is set (listing "launch_template" is redundant and warns). auto_rollback reverts a
+  #     failed refresh to the prior LT version. min/max healthy mirror the maintenance policy.
+  #
+  # ROLLBACK RUNBOOK (avoid the rollback loop): version = latest_version, so a bad deploy
+  # makes LT vN (latest) and auto_rollback reverts the ASG to vN-1, but the config still
+  # resolves to vN. Re-applying Terraform RE-TRIGGERS the same failed refresh. To recover
+  # you MUST revert var.app_image to the last-good tag/digest (which produces a NEW good LT
+  # version), then apply. Do not just click apply on the failed run. Pin app_image by
+  # @sha256: digest in prod so rollback state and config converge on a known artifact (D10).
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 100
+      max_healthy_percentage = 200
+      auto_rollback          = true
+      skip_matching          = false
+      instance_warmup        = 120
+    }
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "femiwiki-app"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [desired_capacity] # do not fight the transient deploy surge / manual scaling
+  }
+}

--- a/aws/res/Hotfix.php
+++ b/aws/res/Hotfix.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Use this file for hotfixes
+ *
+ * @file
+ */
+
+$wgAutoConfirmAge = 3600;
+$wgUnifiedExtensionForFemiwikiBlockByEmail = false;
+$wgUnifiedExtensionForFemiwikiRelatedArticlesUseLinks = false;
+
+# Extension:Lockdown
+$wgActionLockdown = [
+	'history' => [ 'user' ],
+	'info' => [ 'user' ],
+	'raw' => [ 'user' ],
+];
+$wgSpecialPageLockdown = [
+	'AbuseFilter' => [ 'user' ],
+	'Recentchangeslinked' => [ 'user' ],
+	'Contributions' => [ 'user' ],
+	'Whatlinkshere' => [ 'user' ],
+	'Log' => [ 'user' ],
+];
+
+foreach ( [
+	NS_TALK,
+	NS_USER_TALK,
+	NS_PROJECT_TALK,
+	NS_FILE_TALK,
+	NS_MEDIAWIKI_TALK,
+	NS_TEMPLATE_TALK,
+	NS_HELP_TALK,
+	NS_CATEGORY_TALK,
+	NS_ITEM_TALK,
+	NS_PROPERTY_TALK,
+	NS_WIDGET_TALK,
+	NS_MODULE_TALK,
+	NS_TRANSLATIONS_TALK,
+	NS_GADGET_TALK,
+	NS_GADGET_DEFINITION_TALK,
+	NS_NEWSLETTER_TALK,
+	NS_BBS,
+	NS_BBS_TALK,
+] as $space ) {
+	$wgNamespaceContentModels[$space] = CONTENT_MODEL_WIKITEXT;
+}
+
+// Maintenance
+// 점검이 끝나면 아래 라인 주석처리한 뒤, 아래 문서 내용을 비우면 됨
+// https://femiwiki.com/w/%EB%AF%B8%EB%94%94%EC%96%B4%EC%9C%84%ED%82%A4:Sitenotice
+// $wgReadOnly = '데이터베이스 업그레이드 작업이 진행 중입니다. 작업이 진행되는 동안 사이트 이용이 제한됩니다.';
+
+// 업로드를 막고싶을때엔 아래 라인 주석 해제하면 됨
+// $wgEnableUploads = false;

--- a/aws/res/config.alloy.tftpl
+++ b/aws/res/config.alloy.tftpl
@@ -83,6 +83,12 @@ prometheus.exporter.unix "integrations_node_exporter" {
   netdev {
     device_exclude = "^(veth.*|cali.*|[a-f0-9]{15})$"
   }
+  # Surface the edge reconciler's Prometheus textfile (femiwiki_reconciler_*). Convenience
+  # only; the load-bearing alarm path is CloudWatch (app-reconciler.tf). On app nodes the
+  # directory is simply empty.
+  textfile {
+    directory = "/var/lib/node_exporter/textfile"
+  }
 }
 prometheus.scrape "integrations_node_exporter" {
   targets    = discovery.relabel.integrations_node_exporter.output

--- a/aws/res/femiwiki-reconciler-caddywatch.service
+++ b/aws/res/femiwiki-reconciler-caddywatch.service
@@ -1,0 +1,15 @@
+# Re-apply on Caddy (re)start: admin-API PATCHes are NOT persisted to the Caddyfile, so a
+# Caddy reload resets upstreams to the {$BACKEND_UPSTREAMS} seed. This kicks a reconcile
+# within ~1s of the `http` container starting; bootstrap_id then re-seeds last-good.
+[Unit]
+Description=Kick the reconciler whenever the Caddy (http) container starts
+After=docker.service
+Requires=docker.service
+
+[Service]
+Restart=always
+RestartSec=5
+ExecStart=/bin/sh -c 'docker events --filter container=http --filter event=start --format "{{.Actor.Attributes.name}}" | while read -r _; do systemctl start --no-block femiwiki-reconciler.service; done'
+
+[Install]
+WantedBy=multi-user.target

--- a/aws/res/femiwiki-reconciler.env
+++ b/aws/res/femiwiki-reconciler.env
@@ -1,0 +1,12 @@
+# target: edge /etc/femiwiki/reconciler.env
+ASG_NAME=femiwiki-app
+TERMINATE_HOOK=femiwiki-app-terminate
+AWS_DEFAULT_REGION=ap-northeast-1
+BACKEND_PORT=8080
+CADDY_CONTAINER=http
+# The edge `http` image bakes its Caddyfile at /srv/femiwiki.com/Caddyfile
+# (Dockerfile: COPY Caddyfile -> /srv/femiwiki.com/ + WORKDIR /srv/femiwiki.com).
+CADDY_CONFIG_PATH=/srv/femiwiki.com/Caddyfile
+READY_PATH=/healthz-ready
+LIVE_PATH=/healthz-live
+DRAIN_WINDOW=20

--- a/aws/res/femiwiki-reconciler.service
+++ b/aws/res/femiwiki-reconciler.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Femiwiki edge upstream reconciler (ASG -> Caddy admin API)
+After=docker.service network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/femiwiki/reconciler.env
+ExecStart=/usr/local/sbin/femiwiki-reconciler.sh
+TimeoutStartSec=60
+Nice=5
+ProtectSystem=full
+NoNewPrivileges=true

--- a/aws/res/femiwiki-reconciler.sh
+++ b/aws/res/femiwiki-reconciler.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Femiwiki edge reconciler.
+#
+# Resolves the backend ASG (InService + HEALTHY) -> private IPs, gates each node on a
+# direct /healthz-ready probe, and publishes the result as the edge Caddy reverse_proxy
+# upstreams via the admin API (atomic add-before-remove PATCH on the @id-tagged handler).
+# Couples the TERMINATING lifecycle hook with a real drain window. Floor-of-one: never
+# publishes an empty upstream set. Idempotent + crash-only: safe to run every ~20s and on
+# every Caddy (re)start.
+#
+# The LAUNCHING hook is owned by the node's own user-data (it polls local /healthz-ready
+# then CompleteLifecycleAction). This daemon does NOT touch the launch hook (single owner).
+set -euo pipefail
+
+# ---- config (overridable via /etc/femiwiki/reconciler.env) -------------------
+: "${AWS_DEFAULT_REGION:=ap-northeast-1}"
+: "${ASG_NAME:?ASG_NAME is required}"
+: "${TERMINATE_HOOK:=femiwiki-app-terminate}"
+: "${BACKEND_PORT:=8080}"
+# Add-gate: a NEW node must pass real readiness (DB + memcached + session store) to JOIN.
+: "${READY_PATH:=/healthz-ready}"
+# Keep/evict: an EXISTING node is only removed/evicted on process LIVENESS failure, so a
+# shared MySQL/memcached blip cannot eject the fleet (decoupled from readiness; see D4).
+: "${LIVE_PATH:=/healthz-live}"
+: "${CADDY_ADMIN:=http://localhost:2019}"
+: "${CADDY_ID:=backend_upstreams}"
+: "${CADDY_CONTAINER:=http}"
+# The edge `http` image bakes its Caddyfile at /srv/femiwiki.com/Caddyfile (Dockerfile:
+# COPY Caddyfile into /srv/femiwiki.com/ + WORKDIR /srv/femiwiki.com). NOT /etc/caddy.
+: "${CADDY_CONFIG_PATH:=/srv/femiwiki.com/Caddyfile}"
+: "${STATE_DIR:=/var/lib/femiwiki-reconciler}"
+: "${TEXTFILE_DIR:=/var/lib/node_exporter/textfile}"
+: "${PROBE_TIMEOUT:=3}"
+: "${UNHEALTHY_THRESHOLD:=3}"
+# Seconds an instance must remain OUT of upstreams before its terminate hook is released,
+# so in-flight requests on the draining node finish before the EC2 instance is terminated.
+: "${DRAIN_WINDOW:=20}"
+: "${CW_NAMESPACE:=Femiwiki/Reconciler}"
+export AWS_DEFAULT_REGION
+
+LAST_GOOD="${STATE_DIR}/upstreams.json"
+LIVEDIR="${STATE_DIR}/livefail"
+TERMDIR="${STATE_DIR}/terminating"
+mkdir -p "$STATE_DIR" "$LIVEDIR" "$TERMDIR" "$TEXTFILE_DIR"
+
+log() { printf '%s reconciler: %s\n' "$(date -u +%FT%TZ)" "$*" >&2; }
+
+patch_failures=0
+aws_errors=0
+success=0
+upstream_count=0
+floor_breach=0
+draining=0
+
+emit_metrics() {
+  local now tmp
+  now=$(date +%s)
+  tmp="${TEXTFILE_DIR}/.femiwiki_reconciler.prom.$$"
+  {
+    echo "# TYPE femiwiki_reconciler_up gauge"
+    echo "femiwiki_reconciler_up ${success}"
+    echo "# TYPE femiwiki_reconciler_last_success_timestamp_seconds gauge"
+    [ "$success" = 1 ] && echo "femiwiki_reconciler_last_success_timestamp_seconds ${now}"
+    echo "# TYPE femiwiki_reconciler_upstream_count gauge"
+    echo "femiwiki_reconciler_upstream_count ${upstream_count}"
+    echo "# TYPE femiwiki_reconciler_floor_breach gauge"
+    echo "femiwiki_reconciler_floor_breach ${floor_breach}"
+    echo "# TYPE femiwiki_reconciler_draining gauge"
+    echo "femiwiki_reconciler_draining ${draining}"
+    echo "# TYPE femiwiki_reconciler_patch_failures_total counter"
+    echo "femiwiki_reconciler_patch_failures_total ${patch_failures}"
+    echo "# TYPE femiwiki_reconciler_aws_errors_total counter"
+    echo "femiwiki_reconciler_aws_errors_total ${aws_errors}"
+  } > "$tmp" && mv -f "$tmp" "${TEXTFILE_DIR}/femiwiki_reconciler.prom"
+  # CloudWatch is the load-bearing alarm path (PutMetricData granted by
+  # CloudWatchAgentServerPolicy already on the edge role).
+  aws cloudwatch put-metric-data --namespace "$CW_NAMESPACE" --metric-data \
+    "MetricName=UpstreamCount,Value=${upstream_count},Unit=Count" \
+    "MetricName=ReconcilerHeartbeat,Value=${success},Unit=Count" >/dev/null 2>&1 || true
+}
+trap emit_metrics EXIT
+
+aws_q() { aws "$@" 2>/dev/null || { aws_errors=$((aws_errors + 1)); return 1; }; }
+probe() { [ "$(curl -fsS -m "$PROBE_TIMEOUT" -o /dev/null -w '%{http_code}' "http://$1:${BACKEND_PORT}$2" 2>/dev/null)" = 200 ]; }
+caddy_current() { curl -fsS -m 5 "${CADDY_ADMIN}/id/${CADDY_ID}/upstreams" | jq -r '.[].dial' | sort; }
+
+# Adapt the LIVE Caddyfile, inject @id + seed last-good upstreams, POST /load.
+bootstrap_id() {
+  local seed='[]'
+  [ -s "$LAST_GOOD" ] && seed="$(cat "$LAST_GOOD")"
+  log "bootstrap: injecting @id=${CADDY_ID} (config=${CADDY_CONFIG_PATH})"
+  if ! docker exec "$CADDY_CONTAINER" caddy adapt \
+    --config "$CADDY_CONFIG_PATH" --adapter caddyfile \
+    | jq --arg id "$CADDY_ID" --argjson seed "$seed" '
+        (.. | objects | select(.handler? == "reverse_proxy"))
+          |= (. + {"@id": $id} + (if ($seed|length) > 0 then {upstreams: $seed} else {} end))' \
+    | curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
+        --data-binary @- "${CADDY_ADMIN}/load"; then
+    log "bootstrap: /load failed"
+    patch_failures=$((patch_failures + 1))
+    return 1
+  fi
+}
+
+exec 9>"${STATE_DIR}/.lock"
+flock -n 9 || { log "another run holds the lock; skipping"; exit 0; }
+
+# 1. instances of THIS ASG only
+asg=$(aws_q autoscaling describe-auto-scaling-instances \
+  --query "AutoScalingInstances[?AutoScalingGroupName=='${ASG_NAME}']" --output json) \
+  || { log "describe-asg-instances failed"; exit 0; }
+
+serving_ids=$(echo "$asg" | jq -r '.[] | select(.HealthStatus=="HEALTHY") | select(.LifecycleState=="InService") | .InstanceId')
+term_ids=$(echo "$asg" | jq -r '.[] | select(.LifecycleState | startswith("Terminating:Wait")) | .InstanceId')
+
+# 2. private IPs of the serving candidates
+declare -A IP_OF
+if [ -n "$serving_ids" ]; then
+  # shellcheck disable=SC2086,SC2016
+  ipmap=$(aws_q ec2 describe-instances --instance-ids $serving_ids \
+    --query 'Reservations[].Instances[?State.Name==`running`].{id:InstanceId,ip:PrivateIpAddress}' \
+    --output json | jq -r '.[][] | "\(.id) \(.ip)"') || { log "describe-instances failed"; exit 0; }
+  while read -r id ip; do
+    [ -z "${ip:-}" ] && continue
+    IP_OF["$id"]="$ip"
+  done <<< "$ipmap"
+fi
+
+# previous published set (sticky membership)
+last_set=()
+if [ -s "$LAST_GOOD" ]; then
+  mapfile -t last_set < <(jq -r '.[].dial' "$LAST_GOOD" 2>/dev/null)
+fi
+was_in() {
+  local d="$1" x
+  for x in "${last_set[@]:-}"; do [ "$x" = "$d" ] && return 0; done
+  return 1
+}
+
+# 3. build the desired set: a node must be LIVE; readiness is required only to JOIN, never
+#    to stay (was_in). This + health_uri=/healthz-live in Caddy decouples shared-dep blips
+#    from ejection. Track liveness failures for eviction.
+ready_dials=()
+for id in $serving_ids; do
+  ip="${IP_OF[$id]:-}"
+  [ -z "$ip" ] && continue
+  dial="${ip}:${BACKEND_PORT}"
+  if probe "$ip" "$LIVE_PATH"; then
+    rm -f "${LIVEDIR}/${id}"
+    if probe "$ip" "$READY_PATH" || was_in "$dial"; then
+      ready_dials+=("$dial")
+    else
+      log "join-gate HOLD ${id} ${ip} (live but not yet ready)"
+    fi
+  else
+    c=$(( $(cat "${LIVEDIR}/${id}" 2>/dev/null || echo 0) + 1 ))
+    echo "$c" > "${LIVEDIR}/${id}"
+    log "liveness FAIL ${id} ${ip} (consecutive=${c})"
+  fi
+done
+
+desired=""
+if [ "${#ready_dials[@]}" -gt 0 ]; then
+  desired=$(printf '%s\n' "${ready_dials[@]}" | sort -u)
+fi
+[ -n "$desired" ] && upstream_count=$(printf '%s\n' "$desired" | grep -c .)
+in_desired() { printf '%s\n' "$desired" | grep -qx "$1"; }
+
+# 4. FLOOR-OF-ONE: never publish an empty set; keep last-good and alarm.
+if [ "$upstream_count" -lt 1 ]; then
+  log "ZERO ready upstreams -> refusing to PATCH; keeping last-good. ALARM."
+  floor_breach=1
+  exit 0
+fi
+
+# 5. diff vs Caddy, atomic add-before-remove PATCH (whole-config reload, rolled back on err)
+if ! current=$(caddy_current); then
+  bootstrap_id || exit 0
+  current=$(caddy_current || true)
+fi
+body=$(printf '%s\n' "$desired" | grep . | jq -R . | jq -s 'map({dial: .})')
+if [ "$desired" != "$current" ]; then
+  if curl -fsS -m 10 -X PATCH -H 'Content-Type: application/json' \
+    -d "$body" "${CADDY_ADMIN}/id/${CADDY_ID}/upstreams" >/dev/null; then
+    log "PATCHed upstreams -> $(echo "$desired" | tr '\n' ' ')"
+    printf '%s' "$body" > "$LAST_GOOD"
+  else
+    log "PATCH failed"
+    patch_failures=$((patch_failures + 1))
+    exit 0
+  fi
+else
+  printf '%s' "$body" > "$LAST_GOOD"
+fi
+
+# 6. TERMINATE hook: the node is already out of upstreams (it is not in serving_ids). Hold
+#    a real drain window (record removed_at on first sighting) so in-flight requests finish,
+#    and only CONTINUE once a healthy peer survives. Heartbeat to keep the hook alive.
+cur_terms=" $(echo "$term_ids" | tr '\n' ' ') "
+now=$(date +%s)
+for id in $term_ids; do
+  stamp="${TERMDIR}/${id}"
+  [ -f "$stamp" ] || echo "$now" > "$stamp"
+  removed_at=$(cat "$stamp")
+  age=$(( now - removed_at ))
+  if [ "$upstream_count" -ge 1 ] && [ "$age" -ge "$DRAIN_WINDOW" ]; then
+    log "terminate-gate PASS ${id}: drained ${age}s, ${upstream_count} peer(s) -> CONTINUE"
+    aws_q autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE \
+      --lifecycle-hook-name "$TERMINATE_HOOK" --auto-scaling-group-name "$ASG_NAME" \
+      --instance-id "$id" >/dev/null && rm -f "$stamp" || true
+  else
+    draining=$((draining + 1))
+    log "terminate-gate DRAIN ${id}: age=${age}s/${DRAIN_WINDOW}s peers=${upstream_count} -> heartbeat"
+    aws_q autoscaling record-lifecycle-action-heartbeat \
+      --lifecycle-hook-name "$TERMINATE_HOOK" --auto-scaling-group-name "$ASG_NAME" \
+      --instance-id "$id" >/dev/null || true
+  fi
+done
+# prune stale terminate stamps (instances no longer terminating)
+for stamp in "$TERMDIR"/*; do
+  [ -e "$stamp" ] || continue
+  sid=$(basename "$stamp")
+  case "$cur_terms" in *" $sid "*) : ;; *) rm -f "$stamp" ;; esac
+done
+
+# 7. blackhole protection: evict an InService node that keeps failing LIVENESS, only if a
+#    healthy (live) peer survives. Uses liveness, not readiness, so a DB blip never evicts.
+for id in $serving_ids; do
+  c=$(cat "${LIVEDIR}/${id}" 2>/dev/null || echo 0)
+  if [ "$c" -ge "$UNHEALTHY_THRESHOLD" ]; then
+    peer=$(printf '%s\n' "$desired" | grep -vx "${IP_OF[$id]:-x}:${BACKEND_PORT}" | grep -c . || true)
+    if [ "${peer:-0}" -ge 1 ]; then
+      log "SetInstanceHealth Unhealthy ${id} (failed ${c} liveness probes)"
+      aws_q autoscaling set-instance-health --instance-id "$id" --health-status Unhealthy >/dev/null \
+        && rm -f "${LIVEDIR}/${id}" || true
+    fi
+  fi
+done
+
+success=1
+log "done: ${upstream_count} upstream(s), ${draining} draining"

--- a/aws/res/femiwiki-reconciler.timer
+++ b/aws/res/femiwiki-reconciler.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Femiwiki edge reconciler every 20s
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=20s
+AccuracySec=1s
+Unit=femiwiki-reconciler.service
+
+[Install]
+WantedBy=timers.target

--- a/aws/res/install-reconciler.sh.tftpl
+++ b/aws/res/install-reconciler.sh.tftpl
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+# Idempotent install/refresh of the Femiwiki edge reconciler (run by SSM, on a schedule).
+
+# AWS CLI v2 (arm64) if missing (the edge has none baked).
+if ! command -v aws >/dev/null 2>&1; then
+  curl -fsSLo /tmp/awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+  unzip -q -o /tmp/awscliv2.zip -d /tmp && /tmp/aws/install --update && hash -r
+fi
+
+install -d /etc/femiwiki /var/lib/femiwiki-reconciler /var/lib/node_exporter/textfile
+chmod 0755 /var/lib/node_exporter/textfile
+
+cat > /etc/femiwiki/reconciler.env <<'R_ENV'
+${reconciler_env}
+R_ENV
+
+cat > /usr/local/sbin/femiwiki-reconciler.sh <<'R_SH'
+${reconciler_sh}
+R_SH
+chmod 0755 /usr/local/sbin/femiwiki-reconciler.sh
+
+cat > /etc/systemd/system/femiwiki-reconciler.service <<'R_SVC'
+${unit_service}
+R_SVC
+
+cat > /etc/systemd/system/femiwiki-reconciler.timer <<'R_TMR'
+${unit_timer}
+R_TMR
+
+cat > /etc/systemd/system/femiwiki-reconciler-caddywatch.service <<'R_CW'
+${unit_caddywatch}
+R_CW
+
+systemctl daemon-reload
+systemctl enable --now femiwiki-reconciler.timer femiwiki-reconciler-caddywatch.service
+
+# Smoke test (non-fatal): the baked Caddyfile path must adapt, and one reconcile pass must
+# publish an upstream set. Closes the CADDY_CONFIG_PATH gap.
+docker exec http caddy adapt --config /srv/femiwiki.com/Caddyfile --adapter caddyfile >/dev/null 2>&1 \
+  && echo "smoke: caddy adapt OK" || echo "smoke: caddy adapt FAILED (check CADDY_CONFIG_PATH)"
+systemctl start femiwiki-reconciler.service || true

--- a/aws/res/user-data-app.sh.tftpl
+++ b/aws/res/user-data-app.sh.tftpl
@@ -1,0 +1,193 @@
+#!/bin/bash
+# Femiwiki backend ASG node bootstrap (AL2023 host runs the FrankenPHP container).
+# Rendered by templatefile(): TF vars are ${region} etc; bash vars use no braces.
+# A literal curl percent-brace token is written escaped (double-percent) below.
+set -euo pipefail
+set -x
+export PATH=/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin
+
+REGION="${region}"
+IMAGE="${image}"
+LAUNCH_HOOK="${launch_hook_name}"
+
+# --- 0. IMDSv2: this instance's id + its ASG name (exposed via instance_metadata_tags) ---
+imds() {
+  local t
+  t=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+  curl -sf -H "X-aws-ec2-metadata-token: $t" "http://169.254.169.254/latest/meta-data/$1"
+}
+IID=$(imds instance-id)
+ASG=$(imds "tags/instance/aws:autoscaling:groupName")
+
+# Fail-safe: any unhandled error before we gate -> ABANDON the launch (ASG terminates
+# the node, instance_refresh auto_rollback reverts). Cleared once we send a result.
+abandon() {
+  aws autoscaling complete-lifecycle-action --region "$REGION" \
+    --lifecycle-action-result ABANDON --lifecycle-hook-name "$LAUNCH_HOOK" \
+    --auto-scaling-group-name "$ASG" --instance-id "$IID" >/dev/null 2>&1 || true
+}
+trap abandon ERR
+
+# --- 1. packages: docker + jq + AWS CLI v2 (arm64) ---
+dnf install -y docker jq unzip
+systemctl enable --now docker
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscliv2.zip
+unzip -q -o /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install --update
+hash -r
+
+# --- 2. Grafana Alloy (metrics/logs), creds substituted from SSM below ---
+curl -sLo /tmp/grafana.gpg https://rpm.grafana.com/gpg.key
+rpm --import /tmp/grafana.gpg
+{
+  echo '[grafana]'
+  echo 'name=grafana'
+  echo 'baseurl=https://rpm.grafana.com'
+  echo 'repo_gpgcheck=1'
+  echo 'enabled=1'
+  echo 'gpgcheck=1'
+  echo 'gpgkey=https://rpm.grafana.com/gpg.key'
+  echo 'sslverify=1'
+} > /etc/yum.repos.d/grafana.repo
+dnf install -y alloy
+
+# --- 3. fetch secrets from SSM (runtime GetParameter; AppNode IAM policy) ---
+get_ssm() {
+  aws ssm get-parameter --region "$REGION" --name "$1" --with-decryption \
+    --query 'Parameter.Value' --output text
+}
+DB_USER=$(get_ssm /mysql/users/mediawiki/username)
+DB_PASSWORD=$(get_ssm /mysql/users/mediawiki/password)
+WG_SECRET_KEY=$(get_ssm /mediawiki/site_key)
+WG_O_AUTH_2_PRIVATE_KEY=$(get_ssm /mediawiki/o_auth_2_private_key)
+WG_RC_FEEDS_DISCORD_URL=$(get_ssm /mediawiki/rc_feeds_discord_url)
+WG_RE_CAPTCHA_SECRET_KEY=$(get_ssm /mediawiki/re_captcha/secret_key)
+WG_RE_CAPTCHA_SITE_KEY=$(get_ssm /mediawiki/re_captcha/site_key)
+WG_SMTP_PASSWORD=$(get_ssm /mediawiki/smtp/password)
+WG_SMTP_USERNAME=$(get_ssm /mediawiki/smtp/username)
+WG_UPGRADE_KEY=$(get_ssm /mediawiki/upgrade_key)
+PROM_PW=$(get_ssm /alloy/prometheus_password)
+LOKI_PW=$(get_ssm /alloy/loki_password)
+
+# --- 4. write alloy config (template has @@..@@ sentinels), substitute creds, start ---
+mkdir -p /etc/alloy
+cat > /etc/alloy/config.alloy <<'ALLOY_EOF'
+${alloy_config}
+ALLOY_EOF
+esc() { printf '%s' "$1" | sed -e 's/[\/&|]/\\&/g'; }
+sed -i "s|@@PROMETHEUS_PASSWORD@@|$(esc "$PROM_PW")|; s|@@LOKI_PASSWORD@@|$(esc "$LOKI_PW")|" /etc/alloy/config.alloy
+chmod 600 /etc/alloy/config.alloy
+systemctl enable --now alloy
+
+# --- 5. MediaWiki env: non-secret (Terraform-rendered) then secrets (literal) ---
+install -d -m 0700 /etc/femiwiki
+cat > /etc/femiwiki/app.env <<'ENV_EOF'
+FRANKENPHP_NUM_THREADS=${frankenphp_num_threads}
+SERVER_NAME=:8080
+MEDIAWIKI_SERVER=${mediawiki_server}
+MEDIAWIKI_SKIP_INSTALL=1
+MEDIAWIKI_SKIP_UPDATE=1
+MEDIAWIKI_SKIP_IMPORT_SITES=1
+AWS_REGION=${region}
+S3_USE_IAM_PROVIDER=true
+WG_DB_SERVER=${mysql_endpoint}
+WG_MEMCACHED_SERVERS=${edge_private_ip}:11211
+WG_CDN_SERVERS=${edge_private_ip}:80
+WG_CDN_SERVERS_NO_PURGE=${edge_private_ip}/32,127.0.0.1
+WG_INTERNAL_SERVER=http://${edge_private_ip}
+WG_BOUNCE_HANDLER_INTERNAL_IPS=172.31.0.0/16
+EDGE_CIDR=${edge_private_ip}/32
+ENV_EOF
+{
+  printf 'WG_DB_USER=%s\n'               "$DB_USER"
+  printf 'WG_DB_PASSWORD=%s\n'           "$DB_PASSWORD"
+  printf 'WG_SECRET_KEY=%s\n'            "$WG_SECRET_KEY"
+  printf 'WG_O_AUTH_2_PRIVATE_KEY=%s\n'  "$WG_O_AUTH_2_PRIVATE_KEY"
+  printf 'WG_RC_FEEDS_DISCORD_URL=%s\n'  "$WG_RC_FEEDS_DISCORD_URL"
+  printf 'WG_RE_CAPTCHA_SECRET_KEY=%s\n' "$WG_RE_CAPTCHA_SECRET_KEY"
+  printf 'WG_RE_CAPTCHA_SITE_KEY=%s\n'   "$WG_RE_CAPTCHA_SITE_KEY"
+  printf 'WG_SMTP_PASSWORD=%s\n'         "$WG_SMTP_PASSWORD"
+  printf 'WG_SMTP_USERNAME=%s\n'         "$WG_SMTP_USERNAME"
+  printf 'WG_UPGRADE_KEY=%s\n'           "$WG_UPGRADE_KEY"
+} >> /etc/femiwiki/app.env
+chmod 600 /etc/femiwiki/app.env
+
+# Operator Hotfix snippet (multi-line PHP, must start with <?php). Passed via --env
+# (not --env-file, which cannot hold newlines); entrypoint require_once's it last.
+cat > /etc/femiwiki/user-hotfix.php <<'HOTFIX_EOF_8f3a'
+${hotfix_snippet}
+HOTFIX_EOF_8f3a
+
+# --- 6. run the container under Docker's Restart=always ---
+docker pull "$IMAGE"
+docker rm -f femiwiki-app >/dev/null 2>&1 || true
+docker run -d --name femiwiki-app \
+  --restart always \
+  --network host \
+  --env-file /etc/femiwiki/app.env \
+  --env "MEDIAWIKI_HOTFIX_SNIPPET=$(cat /etc/femiwiki/user-hotfix.php)" \
+  --ulimit nofile=32768:65536 \
+  "$IMAGE"
+
+# --- 7. self health gate: poll the REAL readiness, then complete the LAUNCHING hook ---
+RESULT=ABANDON
+for _ in $(seq 1 100); do
+  code=$(curl -fsS -o /dev/null -w '%%{http_code}' --max-time 5 "http://localhost:8080/healthz-ready" || true)
+  if [ "$code" = "200" ]; then RESULT=CONTINUE; break; fi
+  # extend the hook so a slow image pull / boot does not hit DefaultResult=ABANDON
+  aws autoscaling record-lifecycle-action-heartbeat --region "$REGION" \
+    --lifecycle-hook-name "$LAUNCH_HOOK" --auto-scaling-group-name "$ASG" \
+    --instance-id "$IID" || true
+  sleep 5
+done
+aws autoscaling complete-lifecycle-action --region "$REGION" \
+  --lifecycle-action-result "$RESULT" --lifecycle-hook-name "$LAUNCH_HOOK" \
+  --auto-scaling-group-name "$ASG" --instance-id "$IID"
+trap - ERR
+
+# --- 8. watchdog: if the container dies or goes unready, mark the node Unhealthy
+#        so the ASG (EC2 health) replaces it. (No TF interpolation below.) ---
+cat > /usr/local/bin/femiwiki-watchdog.sh <<'WD_EOF'
+#!/bin/bash
+set -u
+REGION="ap-northeast-1"
+fails=0
+imds() {
+  local t
+  t=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+  curl -sf -H "X-aws-ec2-metadata-token: $t" "http://169.254.169.254/latest/meta-data/$1"
+}
+while true; do
+  running=$(docker inspect -f '{{.State.Running}}' femiwiki-app 2>/dev/null || echo false)
+  if [ "$running" = "true" ] && curl -fsS -o /dev/null --max-time 3 "http://localhost:8080/healthz-live"; then
+    fails=0
+  else
+    fails=$((fails + 1))
+    if [ "$fails" -ge 3 ]; then
+      iid=$(imds instance-id)
+      aws autoscaling set-instance-health --region "$REGION" \
+        --instance-id "$iid" --health-status Unhealthy --no-should-respect-grace-period || true
+      fails=0
+    fi
+  fi
+  sleep 15
+done
+WD_EOF
+chmod 0755 /usr/local/bin/femiwiki-watchdog.sh
+
+cat > /etc/systemd/system/femiwiki-watchdog.service <<'UNIT_EOF'
+[Unit]
+Description=Femiwiki backend container watchdog
+After=docker.service
+Requires=docker.service
+
+[Service]
+ExecStart=/usr/local/bin/femiwiki-watchdog.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+UNIT_EOF
+systemctl daemon-reload
+systemctl enable --now femiwiki-watchdog.service

--- a/aws/sg.tf
+++ b/aws/sg.tf
@@ -65,14 +65,31 @@ resource "aws_security_group_rule" "femiwiki_ingress_https" {
   ipv6_cidr_blocks  = ["::/0"]
 }
 
+# Docker daemon TLS (2376) is dialed by the `docker` workspace from HCP Terraform runners
+# (docker/backend.tf: host = tcp://<EIP>:2376). It was world-open; scope it to HCP
+# Terraform's published API egress ranges so only TFC runs can reach the daemon (mTLS
+# client-auth still required on top). A STATIC list is used deliberately: a data.http on
+# app.terraform.io/api/meta/ip-ranges would add a plan-time dependency that can silently
+# lock out the docker workspace if the endpoint is unreachable or the ranges rotate.
+#
+# Source of truth: https://app.terraform.io/api/meta/ip-ranges  (the "api" field).
+# REVIEW periodically; if a TFC apply on the docker workspace starts failing to dial 2376,
+# refresh this list first.
+locals {
+  tfc_api_cidrs = [
+    "75.2.98.97/32",
+    "99.83.150.238/32",
+  ]
+}
+
 resource "aws_security_group_rule" "femiwiki_ingress_docker_tls" {
   security_group_id = aws_security_group.femiwiki.id
-  description       = "Docker TLS"
+  description       = "Docker TLS 2376 - HCP Terraform runners only (was world-open)"
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 2376
   to_port           = 2376
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = local.tfc_api_cidrs
 }
 
 resource "aws_security_group_rule" "femiwiki_egress" {

--- a/docker/container.tf
+++ b/docker/container.tf
@@ -1,6 +1,18 @@
+locals {
+  # Classic femiwiki image used by BOTH the edge Caddy (`http`) and the cron singleton.
+  #
+  # MUST be a REBUILT image that ships the NEW reverse_proxy Caddyfile
+  # (dockers/femiwiki/Caddyfile, section 5). Build + push that image and confirm its
+  # Caddyfile adapts (validation section 8) BEFORE applying this workspace: removing
+  # FASTCGI_ADDR while the OLD php_fastcgi Caddyfile is still baked makes `php_fastcgi`
+  # expand with no upstream -> adapt error -> Caddy fails to start -> edge DOWN.
+  # Pin by @sha256: digest in production.
+  femiwiki_image = "ghcr.io/femiwiki/femiwiki:2026-06-28T17-00-NEWCADDY"
+}
+
 resource "docker_container" "http" {
   name            = "http"
-  image           = "ghcr.io/femiwiki/femiwiki:2026-06-03T08-52-20f42e47"
+  image           = local.femiwiki_image
   command         = ["caddy", "run"]
   restart         = "on-failure"
   max_retry_count = 3
@@ -8,7 +20,11 @@ resource "docker_container" "http" {
 
   env = [
     for k, v in {
-      FASTCGI_ADDR        = "127.0.0.1:9000",
+      # No local php-fpm anymore: the Caddyfile uses reverse_proxy. This is only the
+      # bootstrap SEED for the @id=backend_upstreams handler; the edge reconciler owns the
+      # live set via the admin API. Points at a dead local port on purpose (handle_errors
+      # in the Caddyfile serves a maintenance page until the first reconcile PATCH lands).
+      BACKEND_UPSTREAMS   = "127.0.0.1:8080",
       AWS_REGION          = "ap-northeast-1",
       S3_USE_IAM_PROVIDER = "true",
       S3_HOST             = "s3.ap-northeast-1.amazonaws.com",
@@ -46,38 +62,49 @@ resource "docker_container" "http" {
   }
 }
 
-resource "docker_container" "fastcgi" {
-  name         = "fastcgi"
-  image        = "ghcr.io/femiwiki/femiwiki:2026-06-03T08-52-20f42e47"
+#
+# Cron SINGLETON (edge). The ONLY job runner in the whole system: ASG nodes serve only
+# ($wgJobRunRate=0, FrankenPHP image forbids cron). Runs run-jobs / generate-sitemap /
+# update-special-pages against the shared MySQL + edge memcached. NEVER serves HTTP.
+#
+resource "docker_container" "cron" {
+  name         = "cron"
+  image        = local.femiwiki_image
   network_mode = "host"
   restart      = "always"
+
+  # Mirrors dockers/femiwiki/run (LocalSettings + Hotfix), then runs cron in the foreground.
+  # The image installs the schedule as ROOT'S USER CRONTAB at build time
+  # (mediawiki/Dockerfile: `RUN crontab /tmp/crontab`), so `crontab -l` lists the 3 jobs.
+  # CRITICAL env->cron bridge: each job loads LocalSettings.php which reads ALL config via
+  # getenv() (WG_DB_*/WG_SECRET_KEY/...), but cron SCRUBS the environment. `export -p`
+  # serializes the container env (multiline/PEM-safe) into BASH_ENV; SHELL=/bin/bash is
+  # required (default /bin/sh=dash ignores BASH_ENV). Guarded so a missing user crontab
+  # cannot crash-loop the container, and asserted afterward.
+  command = ["/bin/bash", "-c", <<-EOT
+    set -euo pipefail
+    cp -f /a/LocalSettings.php /srv/femiwiki.com/LocalSettings.php
+    printf '%s' "$MEDIAWIKI_HOTFIX_SNIPPET" > /a/Hotfix.php
+    mkdir -p /run/femiwiki
+    export -p > /run/femiwiki/cron.env
+    existing="$(crontab -l 2>/dev/null || true)"
+    { printf 'SHELL=/bin/bash\nBASH_ENV=/run/femiwiki/cron.env\n'; printf '%s\n' "$existing"; } | crontab -
+    crontab -l | grep -q run-jobs || { echo 'FATAL: run-jobs missing from crontab' >&2; exit 1; }
+    exec cron -f
+  EOT
+  ]
+
   env = [
     for k, v in {
-      PHP_FPM_EMERGENCY_RESTART_THRESHOLD = "5"
-      PHP_FPM_EMERGENCY_RESTART_INTERVAL  = "1m"
-      PHP_FPM_PROCESS_CONTROL_TIMEOUT     = "10s"
-      PHP_FPM_REQUEST_TERMINATE_TIMEOUT   = "30"
-
-      PHP_FPM_PM_MAX_CHILDREN      = "30"
-      PHP_FPM_PM_START_SERVERS     = "2"
-      PHP_FPM_PM_MIN_SPARE_SERVERS = "1"
-      PHP_FPM_PM_MAX_SPARE_SERVERS = "3"
-      PHP_FPM_PM_MAX_REQUESTS      = "200"
-
-      PHP_POST_MAX_SIZE       = "10M"
-      PHP_UPLOAD_MAX_FILESIZE = "10M"
-
       MEDIAWIKI_SKIP_IMPORT_SITES = "1"
       MEDIAWIKI_SKIP_INSTALL      = "1"
-      MEDIAWIKI_SKIP_UPDATE       = "1"
+      MEDIAWIKI_SKIP_UPDATE       = "1" # mandatory: cron must never run update.php (no DDL drift)
       MEDIAWIKI_HOTFIX_SNIPPET    = file("res/Hotfix.php")
 
       WG_BOUNCE_HANDLER_INTERNAL_IPS = "172.31.0.0/16"
-      WG_CDN_SERVERS                 = "127.0.0.1:80"
+      WG_CDN_SERVERS                 = "127.0.0.1:80" # edge Caddy (host net)
       WG_INTERNAL_SERVER             = "http://127.0.0.1:80"
-      WG_MEMCACHED_SERVERS           = "127.0.0.1:11211"
-      # Used by fcgi-probe.php
-      FCGI_URL = "127.0.0.1:9000"
+      WG_MEMCACHED_SERVERS           = "127.0.0.1:11211" # edge memcached (host net)
 
       WG_DB_SERVER             = "${data.terraform_remote_state.aws.outputs.mysql_private_ip}:3306"
       WG_DB_USER               = local.ssm_parameters_mysql["/mysql/users/mediawiki/username"]
@@ -93,25 +120,8 @@ resource "docker_container" "fastcgi" {
     } : "${k}=${v}"
   ]
 
-  healthcheck {
-    test = ["CMD-SHELL", <<-EOF
-      if [ ! -d /srv/fcgi-check ]; then
-        mkdir -p /srv/fcgi-check/
-      fi &&
-      if [ ! -z /srv/fcgi-check/AdoyFastCgiClient.php ]; then
-        curl -L https://github.com/wikimedia/operations-docker-images-production-images/raw/ad68c7cb62e4e01436ab3a34fb961fe8034c2cce/images/php/common/fpm/live-test/AdoyFastCgiClient.php -o /srv/fcgi-check/AdoyFastCgiClient.php
-      fi &&
-      if [ ! -z /srv/fcgi-check/fcgi-probe.php ]; then
-        curl -L https://github.com/wikimedia/operations-docker-images-production-images/raw/ad68c7cb62e4e01436ab3a34fb961fe8034c2cce/images/php/common/fpm/live-test/fcgi-probe.php -o /srv/fcgi-check/fcgi-probe.php
-      fi &&
-      /usr/local/bin/php /srv/fcgi-check/fcgi-probe.php || exit 1
-      EOF
-    ]
-    interval = "5s"
-    timeout  = "1s"
-    retries  = 0
-  }
-
+  # Owns the sitemap volume RW (takes over from the deleted fastcgi). generate-sitemap
+  # writes `--fspath sitemap` into /srv/femiwiki.com/sitemap; the edge `http` serves it RO.
   mounts {
     type      = "volume"
     source    = docker_volume.sitemap.id


### PR DESCRIPTION
> **DRAFT — deploy-time infra, NOT applied.** This is a reviewable package for the zero-downtime migration ([femiwiki#435](https://github.com/femiwiki/femiwiki/issues/435)), authored by a multi-agent review and independently re-validated. Do not merge/apply until the sequencing prerequisites below are met.

## Validation (independent, on this branch)
- `aws` workspace: `terraform fmt -check` ✅, `terraform validate` ✅ **Success** (no warnings).
- `docker` workspace: `terraform fmt -check` ✅, `terraform validate` ✅ **Success**.
- `aws/res/femiwiki-reconciler.sh`: `bash -n` ✅.

## Apply is GATED on (sequencing)
1. **FrankenPHP backend image** ([docker-mediawiki#1019](https://github.com/femiwiki/docker-mediawiki/pull/1019)) shipped to ghcr — `aws/app.tf var.app_image`.
2. **Rebuilt edge image with the new Caddyfile** — `docker/container.tf local.femiwiki_image` is pinned to a placeholder tag `…NEWCADDY`; that image (the classic femiwiki image whose Caddy `reverse_proxy`es to the backend instead of local php-fpm) must exist first. The **edge Caddyfile diff is §5 of the package below** and goes in a separate `docker-mediawiki` PR.
3. **CACHE_DB objectcache table**: run `update.php` (creates `objectcache`) before the first ASG node boots; accept the one-time session reset.
4. Apply order: `aws` (ASG/IAM/SG/reconciler) → bake the reconciler → `docker` (repoint edge http, swap fastcgi→cron). See §7/§8.

## ⚠️ TODO before apply: sitemap → S3 (operator chose Option A)
This package was generated with the **NO-S3** sitemap assumption (cron writes local, edge `file_server` serves `/sitemap`). The operator chose **Option A (edge proxies S3)**. Fold in:
- **cron container** (`docker/container.tf`): after `generateSitemap`, `aws s3 sync <local> s3://<bucket>/sitemap/`.
- **edge Caddyfile** (the docker-mediawiki edge PR): replace the `/sitemap` `file_server` with `reverse_proxy /sitemap/* <bucket>.s3.<region>.amazonaws.com` (sitemap prefix public-read). Edge becomes fully stateless re: the sitemap.
- The edge `Femiwiki` IAM role already has `AmazonS3Access`, so no new IAM for the cron S3 write.

## New file `aws/res/Hotfix.php`
Backend-node hotfix delivered by the launch template (the ASG node has no per-container TF apply to inline it). Review alongside §3/§6.

---

# Full package (every choice cites real `file:line`; gap-closure map at the end)

All validations pass. The full package is written to disk and validate-clean. Here is the final implementable package.

---

# Femiwiki zero-downtime Step 2/3 — FINAL package (every gap closed, validate-clean)

All files below are written to disk at the cited absolute paths and were just validated:

- `aws` workspace: `terraform fmt -check -recursive` exit 0 · `terraform init -backend=false` exit 0 (aws v6.30.0, tls v4.2.1 from cache; **no `http` provider needed** — see G3) · `terraform validate` **Success** (one benign warning: `triggers=["launch_template"]` is redundant).
- `docker` workspace: `terraform fmt` exit 0 · `init -backend=false` exit 0 · `terraform validate` **Success**.
- `femiwiki-reconciler.sh`: `shellcheck` exit 0 · `bash -n` exit 0. `install-reconciler.sh.tftpl` rendered → `bash -n` exit 0.
- systemd units parse (verify only warns the target `ExecStart` is absent on this build host — expected).
- Caddyfile: braces balanced, exactly one `reverse_proxy` directive (L96), `handle /sitemap/*` (L88) precedes the catch-all `handle {` (L95), `php_fastcgi` gone, `admin localhost:2019` on, `health_uri /healthz-live`, `handle_errors` maintenance page. Live `caddy validate` with `ghcr.io/femiwiki/caddy:1.3.3` is deferred to CI (registry unreachable in this sandbox).

## Gaps closed (mapping)

| Gap | Severity | Closure (real, on disk) |
|---|---|---|
| `CADDY_CONFIG_PATH=/etc/caddy/Caddyfile` wrong | critical | **Verified** via `dockers/femiwiki/Dockerfile` (`COPY Caddyfile -> /srv/femiwiki.com/` + `WORKDIR`). Default in `femiwiki-reconciler.sh` and `reconciler.env` → `/srv/femiwiki.com/Caddyfile`. Smoke test added to `install-reconciler.sh.tftpl`. |
| http/cron image still bakes old Caddyfile | high | `container.tf` `locals.femiwiki_image` (used by both `http` and `cron`) pinned to the **rebuilt** image; prominent comment + §7/§8 sequencing forbid removing `FASTCGI_ADDR` before that image is live. |
| 2376 world-open + needs `http` provider | high | `sg.tf` scoped to a **static** `local.tfc_api_cidrs` (`75.2.98.97/32`, `99.83.150.238/32`). No `data.http`, no `http` provider, no plan-time HTTP dependency (init proved it). |
| terminate hook = no drain | medium | `femiwiki-reconciler.sh` step 6 records `removed_at` in `STATE_DIR/terminating/<id>`, `record-lifecycle-action-heartbeat` until `now-removed_at >= DRAIN_WINDOW` (20s) **and** a healthy peer exists, only then `CONTINUE`. |
| `auto_rollback` + `latest_version` loop | medium | `app.tf` rollback runbook comment: recovery requires **reverting `var.app_image`** (new good LT version), not re-applying; pin by digest (D10). |
| cron `crontab -l` crash under `set -euo pipefail` | medium | **Verified** schedule is root's user crontab (`mediawiki/Dockerfile: RUN crontab /tmp/crontab`). `container.tf` cron command guards `crontab -l 2>/dev/null || true` and asserts `run-jobs` present post-merge. |
| desired=1 steady-state | medium | Documented RTO (D-HA); edge Caddyfile `handle_errors` serves a maintenance page during the zero-upstream window; `upstream_count<1` alarm pages fast. |
| `/healthz-ready` shared-dep cascade | medium | Caddy active `health_uri /healthz-live`; reconciler keeps an existing node on **liveness** (`LIVE_PATH`) and requires `/healthz-ready` only to **join** (`READY_PATH`); eviction uses liveness. Readiness reserved for launch gate. |
| `app-reconciler.tf` `validate`-clean claim false | medium | All `res/` files authored; `terraform validate` now **Success** on the full set (templatefile/file() all resolve). |
| launch hook double-completion | low | Reconciler no longer touches the launch hook (single owner = node user-data); `LAUNCH_HOOK` removed from reconciler. |
| `data.aws_region.current.name` deprecated | low | `app-reconciler.tf` uses `local.region` everywhere; `data.aws_region` dropped. |
| LT public-IP depends on unmanaged subnet | low | `app.tf` `network_interfaces { associate_public_ip_address = true, security_groups=[...] }` (SGs moved off `vpc_security_group_ids`). |
| session-store cutover (CACHE_DB) | low | Hard prerequisite documented in §8 apply-time + §9 D-SESSION: run `update.php` (creates `objectcache`) BEFORE first ASG node; accept one-time logout. |

---

## Version pins

| Thing | Pin | Location |
|---|---|---|
| Terraform | `~> 1.0` (tested on 1.15.7) | `aws/base.tf`, `docker/backend.tf` |
| `hashicorp/aws` | `~> 6.7` (resolved 6.30.0) | `aws/base.tf` |
| `hashicorp/tls` | `~> 4.0` (resolved 4.2.1) | `aws/base.tf` |
| `kreuzwerker/docker` | `~> 3.0` | `docker/backend.tf` |
| Host AMI | `data.aws_ami.amazon_linux_2_arm64` (`al2023-ami-minimal-*-arm64`) | `aws/ami.tf` |
| Backend instance | `t4g.small` arm64, AZ `ap-northeast-1a` | `aws/app.tf`, `aws/vpc.tf` |
| FrankenPHP serving image | `ghcr.io/femiwiki/femiwiki-frankenphp:2026-06-28` (deploy lever; digest in prod) | `aws/app.tf` `var.app_image` |
| Classic femiwiki image (edge `http`+`cron`) | `local.femiwiki_image` = `ghcr.io/femiwiki/femiwiki:2026-06-28T17-00-NEWCADDY` (MUST contain the new Caddyfile) | `docker/container.tf` |
| memcached / autoheal / backupbot | `memcached:1.6.23-alpine` / `willfarrell/autoheal:1.1.0` / `ghcr.io/femiwiki/backupbot:2025-08-31T08-55-d756cc34` | `docker/container.tf` (unchanged) |
| Custom Caddy build (validation only) | `ghcr.io/femiwiki/caddy:1.3.3` | edge image |
| AWS CLI on nodes/edge | v2 arm64 (`awscli-exe-linux-aarch64.zip`) | user-data / installer |
| TFC API egress CIDRs (2376) | `75.2.98.97/32`, `99.83.150.238/32` | `aws/sg.tf` `local.tfc_api_cidrs` |

---

# 1. Reconciler (edge)

Runs on `aws_instance.docker`. POSIX bash + aws-cli v2 + curl + jq, driven by a systemd one-shot + 20s timer + a docker-event watcher + an EventBridge kick. Owns the `@id=backend_upstreams` reverse_proxy upstreams via the Caddy admin API (`localhost:2019`). Single-owner launch hook lives in the node user-data; this daemon owns the **terminate** hook (with a real drain window) and blackhole eviction.

Caddy admin-API calls it makes:
- Read: `GET localhost:2019/id/backend_upstreams/upstreams`.
- Bootstrap `@id` on a fresh Caddy (Caddyfile cannot express `@id`): `docker exec http caddy adapt --config /srv/femiwiki.com/Caddyfile --adapter caddyfile | jq '(..|objects|select(.handler=="reverse_proxy")) += {"@id":"backend_upstreams"}' | curl -X POST --data-binary @- localhost:2019/load`.
- Atomic add-before-remove: `PATCH localhost:2019/id/backend_upstreams/upstreams` (whole-config reload, rolled back on failure). A PATCH **resets active-health state**, so a just-added upstream is treated available until its first active check — the reconciler's direct `/healthz-ready` join-probe (step 3) is load-bearing.

### `/home/nemo/git/fw/infra/aws/res/femiwiki-reconciler.sh` (→ edge `/usr/local/sbin/femiwiki-reconciler.sh`, 0755)

```bash
#!/usr/bin/env bash
# Femiwiki edge reconciler.
#
# Resolves the backend ASG (InService + HEALTHY) -> private IPs, gates each node on a
# direct /healthz-ready probe, and publishes the result as the edge Caddy reverse_proxy
# upstreams via the admin API (atomic add-before-remove PATCH on the @id-tagged handler).
# Couples the TERMINATING lifecycle hook with a real drain window. Floor-of-one: never
# publishes an empty upstream set. Idempotent + crash-only: safe to run every ~20s and on
# every Caddy (re)start.
#
# The LAUNCHING hook is owned by the node's own user-data (it polls local /healthz-ready
# then CompleteLifecycleAction). This daemon does NOT touch the launch hook (single owner).
set -euo pipefail

# ---- config (overridable via /etc/femiwiki/reconciler.env) -------------------
: "${AWS_DEFAULT_REGION:=ap-northeast-1}"
: "${ASG_NAME:?ASG_NAME is required}"
: "${TERMINATE_HOOK:=femiwiki-app-terminate}"
: "${BACKEND_PORT:=8080}"
# Add-gate: a NEW node must pass real readiness (DB + memcached + session store) to JOIN.
: "${READY_PATH:=/healthz-ready}"
# Keep/evict: an EXISTING node is only removed/evicted on process LIVENESS failure, so a
# shared MySQL/memcached blip cannot eject the fleet (decoupled from readiness; see D4).
: "${LIVE_PATH:=/healthz-live}"
: "${CADDY_ADMIN:=http://localhost:2019}"
: "${CADDY_ID:=backend_upstreams}"
: "${CADDY_CONTAINER:=http}"
# The edge `http` image bakes its Caddyfile at /srv/femiwiki.com/Caddyfile (Dockerfile:
# COPY Caddyfile into /srv/femiwiki.com/ + WORKDIR /srv/femiwiki.com). NOT /etc/caddy.
: "${CADDY_CONFIG_PATH:=/srv/femiwiki.com/Caddyfile}"
: "${STATE_DIR:=/var/lib/femiwiki-reconciler}"
: "${TEXTFILE_DIR:=/var/lib/node_exporter/textfile}"
: "${PROBE_TIMEOUT:=3}"
: "${UNHEALTHY_THRESHOLD:=3}"
# Seconds an instance must remain OUT of upstreams before its terminate hook is released,
# so in-flight requests on the draining node finish before the EC2 instance is terminated.
: "${DRAIN_WINDOW:=20}"
: "${CW_NAMESPACE:=Femiwiki/Reconciler}"
export AWS_DEFAULT_REGION

LAST_GOOD="${STATE_DIR}/upstreams.json"
LIVEDIR="${STATE_DIR}/livefail"
TERMDIR="${STATE_DIR}/terminating"
mkdir -p "$STATE_DIR" "$LIVEDIR" "$TERMDIR" "$TEXTFILE_DIR"

log() { printf '%s reconciler: %s\n' "$(date -u +%FT%TZ)" "$*" >&2; }

patch_failures=0
aws_errors=0
success=0
upstream_count=0
floor_breach=0
draining=0

emit_metrics() {
  local now tmp
  now=$(date +%s)
  tmp="${TEXTFILE_DIR}/.femiwiki_reconciler.prom.$$"
  {
    echo "# TYPE femiwiki_reconciler_up gauge"
    echo "femiwiki_reconciler_up ${success}"
    echo "# TYPE femiwiki_reconciler_last_success_timestamp_seconds gauge"
    [ "$success" = 1 ] && echo "femiwiki_reconciler_last_success_timestamp_seconds ${now}"
    echo "# TYPE femiwiki_reconciler_upstream_count gauge"
    echo "femiwiki_reconciler_upstream_count ${upstream_count}"
    echo "# TYPE femiwiki_reconciler_floor_breach gauge"
    echo "femiwiki_reconciler_floor_breach ${floor_breach}"
    echo "# TYPE femiwiki_reconciler_draining gauge"
    echo "femiwiki_reconciler_draining ${draining}"
    echo "# TYPE femiwiki_reconciler_patch_failures_total counter"
    echo "femiwiki_reconciler_patch_failures_total ${patch_failures}"
    echo "# TYPE femiwiki_reconciler_aws_errors_total counter"
    echo "femiwiki_reconciler_aws_errors_total ${aws_errors}"
  } > "$tmp" && mv -f "$tmp" "${TEXTFILE_DIR}/femiwiki_reconciler.prom"
  # CloudWatch is the load-bearing alarm path (PutMetricData granted by
  # CloudWatchAgentServerPolicy already on the edge role).
  aws cloudwatch put-metric-data --namespace "$CW_NAMESPACE" --metric-data \
    "MetricName=UpstreamCount,Value=${upstream_count},Unit=Count" \
    "MetricName=ReconcilerHeartbeat,Value=${success},Unit=Count" >/dev/null 2>&1 || true
}
trap emit_metrics EXIT

aws_q() { aws "$@" 2>/dev/null || { aws_errors=$((aws_errors + 1)); return 1; }; }
probe() { [ "$(curl -fsS -m "$PROBE_TIMEOUT" -o /dev/null -w '%{http_code}' "http://$1:${BACKEND_PORT}$2" 2>/dev/null)" = 200 ]; }
caddy_current() { curl -fsS -m 5 "${CADDY_ADMIN}/id/${CADDY_ID}/upstreams" | jq -r '.[].dial' | sort; }

# Adapt the LIVE Caddyfile, inject @id + seed last-good upstreams, POST /load.
bootstrap_id() {
  local seed='[]'
  [ -s "$LAST_GOOD" ] && seed="$(cat "$LAST_GOOD")"
  log "bootstrap: injecting @id=${CADDY_ID} (config=${CADDY_CONFIG_PATH})"
  if ! docker exec "$CADDY_CONTAINER" caddy adapt \
    --config "$CADDY_CONFIG_PATH" --adapter caddyfile \
    | jq --arg id "$CADDY_ID" --argjson seed "$seed" '
        (.. | objects | select(.handler? == "reverse_proxy"))
          |= (. + {"@id": $id} + (if ($seed|length) > 0 then {upstreams: $seed} else {} end))' \
    | curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
        --data-binary @- "${CADDY_ADMIN}/load"; then
    log "bootstrap: /load failed"
    patch_failures=$((patch_failures + 1))
    return 1
  fi
}

exec 9>"${STATE_DIR}/.lock"
flock -n 9 || { log "another run holds the lock; skipping"; exit 0; }

# 1. instances of THIS ASG only
asg=$(aws_q autoscaling describe-auto-scaling-instances \
  --query "AutoScalingInstances[?AutoScalingGroupName=='${ASG_NAME}']" --output json) \
  || { log "describe-asg-instances failed"; exit 0; }

serving_ids=$(echo "$asg" | jq -r '.[] | select(.HealthStatus=="HEALTHY") | select(.LifecycleState=="InService") | .InstanceId')
term_ids=$(echo "$asg" | jq -r '.[] | select(.LifecycleState | startswith("Terminating:Wait")) | .InstanceId')

# 2. private IPs of the serving candidates
declare -A IP_OF
if [ -n "$serving_ids" ]; then
  # shellcheck disable=SC2086,SC2016
  ipmap=$(aws_q ec2 describe-instances --instance-ids $serving_ids \
    --query 'Reservations[].Instances[?State.Name==`running`].{id:InstanceId,ip:PrivateIpAddress}' \
    --output json | jq -r '.[][] | "\(.id) \(.ip)"') || { log "describe-instances failed"; exit 0; }
  while read -r id ip; do
    [ -z "${ip:-}" ] && continue
    IP_OF["$id"]="$ip"
  done <<< "$ipmap"
fi

# previous published set (sticky membership)
last_set=()
if [ -s "$LAST_GOOD" ]; then
  mapfile -t last_set < <(jq -r '.[].dial' "$LAST_GOOD" 2>/dev/null)
fi
was_in() {
  local d="$1" x
  for x in "${last_set[@]:-}"; do [ "$x" = "$d" ] && return 0; done
  return 1
}

# 3. build the desired set: a node must be LIVE; readiness is required only to JOIN, never
#    to stay (was_in). This + health_uri=/healthz-live in Caddy decouples shared-dep blips
#    from ejection. Track liveness failures for eviction.
ready_dials=()
for id in $serving_ids; do
  ip="${IP_OF[$id]:-}"
  [ -z "$ip" ] && continue
  dial="${ip}:${BACKEND_PORT}"
  if probe "$ip" "$LIVE_PATH"; then
    rm -f "${LIVEDIR}/${id}"
    if probe "$ip" "$READY_PATH" || was_in "$dial"; then
      ready_dials+=("$dial")
    else
      log "join-gate HOLD ${id} ${ip} (live but not yet ready)"
    fi
  else
    c=$(( $(cat "${LIVEDIR}/${id}" 2>/dev/null || echo 0) + 1 ))
    echo "$c" > "${LIVEDIR}/${id}"
    log "liveness FAIL ${id} ${ip} (consecutive=${c})"
  fi
done

desired=""
if [ "${#ready_dials[@]}" -gt 0 ]; then
  desired=$(printf '%s\n' "${ready_dials[@]}" | sort -u)
fi
[ -n "$desired" ] && upstream_count=$(printf '%s\n' "$desired" | grep -c .)
in_desired() { printf '%s\n' "$desired" | grep -qx "$1"; }

# 4. FLOOR-OF-ONE: never publish an empty set; keep last-good and alarm.
if [ "$upstream_count" -lt 1 ]; then
  log "ZERO ready upstreams -> refusing to PATCH; keeping last-good. ALARM."
  floor_breach=1
  exit 0
fi

# 5. diff vs Caddy, atomic add-before-remove PATCH (whole-config reload, rolled back on err)
if ! current=$(caddy_current); then
  bootstrap_id || exit 0
  current=$(caddy_current || true)
fi
body=$(printf '%s\n' "$desired" | grep . | jq -R . | jq -s 'map({dial: .})')
if [ "$desired" != "$current" ]; then
  if curl -fsS -m 10 -X PATCH -H 'Content-Type: application/json' \
    -d "$body" "${CADDY_ADMIN}/id/${CADDY_ID}/upstreams" >/dev/null; then
    log "PATCHed upstreams -> $(echo "$desired" | tr '\n' ' ')"
    printf '%s' "$body" > "$LAST_GOOD"
  else
    log "PATCH failed"
    patch_failures=$((patch_failures + 1))
    exit 0
  fi
else
  printf '%s' "$body" > "$LAST_GOOD"
fi

# 6. TERMINATE hook: the node is already out of upstreams (it is not in serving_ids). Hold
#    a real drain window (record removed_at on first sighting) so in-flight requests finish,
#    and only CONTINUE once a healthy peer survives. Heartbeat to keep the hook alive.
cur_terms=" $(echo "$term_ids" | tr '\n' ' ') "
now=$(date +%s)
for id in $term_ids; do
  stamp="${TERMDIR}/${id}"
  [ -f "$stamp" ] || echo "$now" > "$stamp"
  removed_at=$(cat "$stamp")
  age=$(( now - removed_at ))
  if [ "$upstream_count" -ge 1 ] && [ "$age" -ge "$DRAIN_WINDOW" ]; then
    log "terminate-gate PASS ${id}: drained ${age}s, ${upstream_count} peer(s) -> CONTINUE"
    aws_q autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE \
      --lifecycle-hook-name "$TERMINATE_HOOK" --auto-scaling-group-name "$ASG_NAME" \
      --instance-id "$id" >/dev/null && rm -f "$stamp" || true
  else
    draining=$((draining + 1))
    log "terminate-gate DRAIN ${id}: age=${age}s/${DRAIN_WINDOW}s peers=${upstream_count} -> heartbeat"
    aws_q autoscaling record-lifecycle-action-heartbeat \
      --lifecycle-hook-name "$TERMINATE_HOOK" --auto-scaling-group-name "$ASG_NAME" \
      --instance-id "$id" >/dev/null || true
  fi
done
# prune stale terminate stamps (instances no longer terminating)
for stamp in "$TERMDIR"/*; do
  [ -e "$stamp" ] || continue
  sid=$(basename "$stamp")
  case "$cur_terms" in *" $sid "*) : ;; *) rm -f "$stamp" ;; esac
done

# 7. blackhole protection: evict an InService node that keeps failing LIVENESS, only if a
#    healthy (live) peer survives. Uses liveness, not readiness, so a DB blip never evicts.
for id in $serving_ids; do
  c=$(cat "${LIVEDIR}/${id}" 2>/dev/null || echo 0)
  if [ "$c" -ge "$UNHEALTHY_THRESHOLD" ]; then
    peer=$(printf '%s\n' "$desired" | grep -vx "${IP_OF[$id]:-x}:${BACKEND_PORT}" | grep -c . || true)
    if [ "${peer:-0}" -ge 1 ]; then
      log "SetInstanceHealth Unhealthy ${id} (failed ${c} liveness probes)"
      aws_q autoscaling set-instance-health --instance-id "$id" --health-status Unhealthy >/dev/null \
        && rm -f "${LIVEDIR}/${id}" || true
    fi
  fi
done

success=1
log "done: ${upstream_count} upstream(s), ${draining} draining"
```

### `/home/nemo/git/fw/infra/aws/res/femiwiki-reconciler.env` (→ `/etc/femiwiki/reconciler.env`)

```ini
# target: edge /etc/femiwiki/reconciler.env
ASG_NAME=femiwiki-app
TERMINATE_HOOK=femiwiki-app-terminate
AWS_DEFAULT_REGION=ap-northeast-1
BACKEND_PORT=8080
CADDY_CONTAINER=http
# The edge `http` image bakes its Caddyfile at /srv/femiwiki.com/Caddyfile
# (Dockerfile: COPY Caddyfile -> /srv/femiwiki.com/ + WORKDIR /srv/femiwiki.com).
CADDY_CONFIG_PATH=/srv/femiwiki.com/Caddyfile
READY_PATH=/healthz-ready
LIVE_PATH=/healthz-live
DRAIN_WINDOW=20
```

### systemd units (`/home/nemo/git/fw/infra/aws/res/`)

`femiwiki-reconciler.service` (oneshot), `femiwiki-reconciler.timer` (`OnBootSec=30s`, `OnUnitActiveSec=20s`), `femiwiki-reconciler-caddywatch.service` (re-applies within ~1s of the `http` container starting, because admin PATCHes are not persisted to the Caddyfile). All three are on disk and parse. The caddywatch + the 20s timer's `bootstrap_id` (which seeds last-good) give a layered no-blackhole guarantee on a Caddy restart.

Metrics emitted: `femiwiki_reconciler_{up,last_success_timestamp_seconds,upstream_count,floor_breach,draining,patch_failures_total,aws_errors_total}` (node_exporter textfile → edge Alloy) + CloudWatch `Femiwiki/Reconciler` `UpstreamCount`/`ReconcilerHeartbeat` (alarms in §3).

### Alloy textfile collector (so the `.prom` ships)

`/home/nemo/git/fw/infra/aws/res/config.alloy.tftpl` — `textfile { directory = "/var/lib/node_exporter/textfile" }` added inside `prometheus.exporter.unix "integrations_node_exporter"` (after the `netdev{}` block). Convenience only; the load-bearing alarm path is CloudWatch.

### Delivery (respects edge `ignore_changes=[user_data]`)

The edge is a pet (`ec2.tf` `lifecycle{ignore_changes=[user_data]}`), so delivery is via SSM Run Command, not user-data. `/home/nemo/git/fw/infra/aws/res/install-reconciler.sh.tftpl` (rendered + `bash -n` clean) installs AWS CLI v2 if missing, drops the script/env/units, `daemon-reload`, `enable --now` the timer + caddywatch, then runs a **smoke test**: `docker exec http caddy adapt --config /srv/femiwiki.com/Caddyfile` and one reconcile pass (closes the critical path gap). Wired in `app-reconciler.tf` (§3).

---

# 2. ASG Terraform — `/home/nemo/git/fw/infra/aws/app.tf` (validate-clean)

Key revisions from the on-disk draft:

- **Explicit public IP** (closes the unmanaged-subnet egress gap). SGs moved into the NIC block (they cannot coexist with `vpc_security_group_ids`):

```hcl
  network_interfaces {
    device_index                = 0
    associate_public_ip_address = true
    delete_on_termination       = true
    security_groups = [
      aws_security_group.app.id,
      aws_security_group.mediawiki.id,
    ]
  }
```

- **Rollback runbook** comment on `instance_refresh` (closes the auto_rollback/latest_version loop): recovery requires reverting `var.app_image` to the last-good tag/digest (producing a NEW good LT version), not re-applying the failed run; pin by `@sha256:` in prod.

Unchanged-but-validated structure: `aws_launch_template.app` (t4g.small arm64, AL2023 minimal, IMDSv2 + instance tags, gp3 30G encrypted, `user_data` = `res/user-data-app.sh.tftpl`); `aws_autoscaling_group.app` (`min=1/desired=1/max=2`, AZ-a, `health_check_type=EC2`, `instance_maintenance_policy{min=100,max=200}`, launch + terminate `initial_lifecycle_hook`, `instance_refresh{strategy=Rolling, preferences{min=100,max=200,auto_rollback=true}}`, `ignore_changes=[desired_capacity]`). The `min_healthy_percentage=100` in BOTH the policy and refresh preferences is the verified-required pairing (preference default 90 would silently revert to terminate-then-launch).

### `/home/nemo/git/fw/infra/aws/res/user-data-app.sh.tftpl` (unchanged, validated)

Full boot script (on disk, 193 lines). Highlights consistent with the gap closures: launch hook is owned here (step 7 polls real `/healthz-ready`, then `complete-lifecycle-action`; the reconciler no longer touches it); the watchdog (step 8) probes `/healthz-live` and `SetInstanceHealth Unhealthy` after 3 fails. Secrets fetched at boot via `aws ssm get-parameter --with-decryption` for `/mysql/*`, `/mediawiki/*`, `/alloy/*`. `MEDIAWIKI_SKIP_UPDATE=1` (no DDL on nodes). `/home/nemo/git/fw/infra/aws/res/Hotfix.php` is a byte-identical copy of `docker/res/Hotfix.php` (D5).

---

# 3. IAM + delivery + alarms

### `/home/nemo/git/fw/infra/aws/app-iam.tf` (unchanged, validated)

`aws_iam_role.App` + instance profile; `AppNode` policy (`ssm:GetParameter*` on `/mediawiki/* /mysql/* /alloy/*`, `kms:Decrypt` via `kms:ViaService=ssm.<region>`, `autoscaling:CompleteLifecycleAction/RecordLifecycleActionHeartbeat/SetInstanceHealth` scoped to `local.app_asg_arn_glob`); attaches `amazon_s3_access` + `AmazonSSMManagedInstanceCore` + `CloudWatchAgentServerPolicy`. `Reconciler` policy (Describe* on `*`, the three write actions scoped to the ASG) attached to the existing `aws_iam_role.femiwiki`. `cloudwatch:PutMetricData` needs no new policy (CloudWatchAgentServerPolicy already on the edge role). The `app_asg_arn_glob` is constructed from `local.region` + account id (avoids the role→profile→LT→ASG→role cycle).

### `/home/nemo/git/fw/infra/aws/app-ssm.tf` (unchanged, validated)

`/alloy/prometheus_password` and `/alloy/loki_password` SecureString params (from existing `var.prometheus_password`/`var.loki_password`).

### `/home/nemo/git/fw/infra/aws/app-reconciler.tf` (NEW, validated) — delivery + EventBridge + alarms

```hcl
#
# Edge reconciler delivery + event wiring + alarms.
#
# The edge (aws_instance.docker) is a pet with lifecycle { ignore_changes=[user_data] }
# (ec2.tf), so a user-data edit will NOT update the live box. The script + units are
# delivered Terraform-managed and self-healing via SSM Run Command (the edge already has
# AmazonSSMManagedInstanceCore). region comes from local.region (app-iam.tf); we avoid
# data.aws_region (its `.name` is deprecated in aws ~> 6.x).
#

# --- deliver script + env + units to the edge, idempotently, on a schedule ---
resource "aws_ssm_document" "reconciler_install" {
  name            = "FemiwikiReconcilerInstall"
  document_type   = "Command"
  document_format = "YAML"
  content = yamlencode({
    schemaVersion = "2.2"
    description   = "Install/refresh the Femiwiki edge reconciler"
    mainSteps = [{
      action = "aws:runShellScript"
      name   = "install"
      inputs = {
        runCommand = [
          templatefile("${path.module}/res/install-reconciler.sh.tftpl", {
            reconciler_sh   = file("${path.module}/res/femiwiki-reconciler.sh")
            reconciler_env  = file("${path.module}/res/femiwiki-reconciler.env")
            unit_service    = file("${path.module}/res/femiwiki-reconciler.service")
            unit_timer      = file("${path.module}/res/femiwiki-reconciler.timer")
            unit_caddywatch = file("${path.module}/res/femiwiki-reconciler-caddywatch.service")
          })
        ]
      }
    }]
  })
}

resource "aws_ssm_association" "reconciler_install" {
  name                = aws_ssm_document.reconciler_install.name
  schedule_expression = "rate(30 minutes)" # self-heal drift; first run is immediate on create
  targets {
    key    = "tag:Name"
    values = ["docker"] # the edge instance (aws_instance.docker, tags.Name="docker")
  }
}

# --- alarms (the load-bearing path; reconciler also ships a node_exporter textfile) ---
resource "aws_cloudwatch_metric_alarm" "reconciler_upstreams_low" {
  alarm_name          = "Femiwiki reconciler upstream_count < 1"
  namespace           = "Femiwiki/Reconciler"
  metric_name         = "UpstreamCount"
  statistic           = "Minimum"
  period              = 60
  evaluation_periods  = 2
  datapoints_to_alarm = 2
  threshold           = 1
  comparison_operator = "LessThanThreshold"
  treat_missing_data  = "breaching" # no data == blind == bad
  alarm_actions       = [aws_sns_topic.cloudwatch_alarms_topic.arn]
  ok_actions          = [aws_sns_topic.cloudwatch_alarms_topic.arn]
}

resource "aws_cloudwatch_metric_alarm" "reconciler_stale" {
  alarm_name          = "Femiwiki reconciler stale (no successful pass)"
  namespace           = "Femiwiki/Reconciler"
  metric_name         = "ReconcilerHeartbeat"
  statistic           = "Maximum"
  period              = 60
  evaluation_periods  = 3
  datapoints_to_alarm = 3
  threshold           = 1
  comparison_operator = "LessThanThreshold"
  treat_missing_data  = "breaching"
  alarm_actions       = [aws_sns_topic.cloudwatch_alarms_topic.arn]
  ok_actions          = [aws_sns_topic.cloudwatch_alarms_topic.arn]
}

# --- EventBridge kick: ASG lifecycle transition -> SSM Run Command on the edge (no Lambda) ---
resource "aws_cloudwatch_event_rule" "asg_lifecycle" {
  name        = "femiwiki-asg-lifecycle-reconcile"
  description = "Kick the edge reconciler on ASG launch/terminate lifecycle actions"
  event_pattern = jsonencode({
    source      = ["aws.autoscaling"]
    detail-type = ["EC2 Instance-launch Lifecycle Action", "EC2 Instance-terminate Lifecycle Action"]
    detail      = { AutoScalingGroupName = [aws_autoscaling_group.app.name] }
  })
}

resource "aws_cloudwatch_event_target" "kick_reconciler" {
  rule     = aws_cloudwatch_event_rule.asg_lifecycle.name
  arn      = "arn:aws:ssm:${local.region}::document/AWS-RunShellScript"
  role_arn = aws_iam_role.eventbridge_ssm.arn
  run_command_targets {
    key    = "tag:Name"
    values = ["docker"]
  }
  input = jsonencode({ commands = ["systemctl start --no-block femiwiki-reconciler.service"] })
}

resource "aws_iam_role" "eventbridge_ssm" {
  name               = "femiwiki-eventbridge-ssm-runcommand"
  assume_role_policy = data.aws_iam_policy_document.eventbridge_assume.json
}

data "aws_iam_policy_document" "eventbridge_assume" {
  statement {
    actions = ["sts:AssumeRole"]
    principals {
      type        = "Service"
      identifiers = ["events.amazonaws.com"]
    }
  }
}

resource "aws_iam_role_policy" "eventbridge_ssm" {
  name   = "send-runshellscript-to-edge"
  role   = aws_iam_role.eventbridge_ssm.id
  policy = data.aws_iam_policy_document.eventbridge_ssm.json
}

data "aws_iam_policy_document" "eventbridge_ssm" {
  statement {
    actions   = ["ssm:SendCommand"]
    resources = ["arn:aws:ssm:${local.region}::document/AWS-RunShellScript"]
  }
  statement {
    actions   = ["ssm:SendCommand"]
    resources = ["arn:aws:ec2:${local.region}:${data.aws_caller_identity.current.account_id}:instance/*"]
    condition {
      test     = "StringEquals"
      variable = "ssm:resourceTag/Name"
      values   = ["docker"]
    }
  }
}
```

First live rollout can also be fired once manually: `aws ssm send-command --document-name FemiwikiReconcilerInstall --targets Key=tag:Name,Values=docker`.

---

# 4. SG Terraform

### `/home/nemo/git/fw/infra/aws/app-sg.tf` (unchanged, validated)

`aws_security_group.app` (no world ingress); `app_ingress_http_from_edge` (8080 from `aws_security_group.femiwiki` only); `app_egress` (all); `femiwiki_ingress_memcached_from_app` (11211 from the app SG only). DB needs no new rule: the LT attaches `aws_security_group.mediawiki`, and `mysql_ingress_mediawiki` (`sg.tf:112`) already grants 3306 from it.

### `/home/nemo/git/fw/infra/aws/sg.tf` — 2376 closed with a STATIC list (no `http` provider)

```hcl
# Docker daemon TLS (2376) is dialed by the `docker` workspace from HCP Terraform runners
# (docker/backend.tf: host = tcp://<EIP>:2376). It was world-open; scope it to HCP
# Terraform's published API egress ranges so only TFC runs can reach the daemon (mTLS
# client-auth still required on top). A STATIC list is used deliberately: a data.http on
# app.terraform.io/api/meta/ip-ranges would add a plan-time dependency that can silently
# lock out the docker workspace if the endpoint is unreachable or the ranges rotate.
#
# Source of truth: https://app.terraform.io/api/meta/ip-ranges  (the "api" field).
# REVIEW periodically; if a TFC apply on the docker workspace starts failing to dial 2376,
# refresh this list first.
locals {
  tfc_api_cidrs = [
    "75.2.98.97/32",
    "99.83.150.238/32",
  ]
}

resource "aws_security_group_rule" "femiwiki_ingress_docker_tls" {
  security_group_id = aws_security_group.femiwiki.id
  description       = "Docker TLS 2376 - HCP Terraform runners only (was world-open)"
  type              = "ingress"
  protocol          = "tcp"
  from_port         = 2376
  to_port           = 2376
  cidr_blocks       = local.tfc_api_cidrs
}
```

No change to `base.tf` (the static list needs no `http` provider; `init` confirmed only `aws` + `tls` resolve). **Verify the two CIDRs against `https://app.terraform.io/api/meta/ip-ranges` (`api` field) before apply.** Mitigated alternatives are D2.

---

# 5. Edge Caddyfile — `/home/nemo/git/fw/docker-mediawiki/dockers/femiwiki/Caddyfile`

`php_fastcgi`/top-level `file_server`/`/w/*` rewrites removed; `admin localhost:2019` on; `/sitemap/*` served locally and ordered BEFORE the catch-all proxy; `reverse_proxy` to the ASG with active checks on `/healthz-live` (decoupled from shared-dep, G8); passive ejection; `stream_close_delay`; `purge_acl` += `172.31.0.0/16`; and a `handle_errors` maintenance page for the zero-upstream / cold-start window (G7).

```caddyfile
{
	# Global options
	storage s3

	# Edge admin API for the reconciler's add-before-remove upstream PATCH. Loopback-bound;
	# reachable by the reconciler because the edge `http` container is network_mode=host.
	# The BACKEND FrankenPHP image sets `admin off`; the EDGE must keep admin ON. On by
	# default, pinned here to document intent. NOTE: admin PATCHes are NOT persisted to this
	# Caddyfile, so the reconciler re-applies on every Caddy (re)start (caddywatch + bootstrap).
	admin localhost:2019

	order mwcache before rewrite
	# NOTE: See @filter for the further details
	order respond before rewrite
}
femiwiki.com *.femiwiki.com 127.0.0.1:80 localhost:80 {
	tls {
		dns route53
	}
	root * /srv/femiwiki.com
	encode gzip
	mwcache {
		ristretto {
			num_counters 10000
			max_cost 1000
			buffer_items 64
		}
		purge_acl {
			10.0.0.0/8
			127.0.0.1
			# Backend-originated purges arrive from WG_CDN_SERVERS=<edge_ip>:80 over the VPC;
			# without this the purge is rejected (D3). Tighten to <edge_ip>/32 if preferred.
			172.31.0.0/16
		}
	}
	header {
		# HSTS
		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
		# Enable XSS filtering for legacy browsers
		X-XSS-Protection "1; mode=block"
		# Block content sniffing, and enable Cross-Origin Read Blocking
		X-Content-Type-Options "nosniff"
		# Avoid clickjacking
		X-Frame-Options "DENY"
	}
	log {
		format json
	}

	respond /health-check 200

	@block_cidr {
		remote_ip {$BLOCKED_CIDR}
	}

	respond @block_cidr 403 {
		close
	}

	# Ignore malformed requests
	@filter0 {
		path /w/특수:내언어/페미위키:대문
		vars_regexp {query} ^=[0-9]{1,5}$
	}
	@filter1 {
		path /
		vars_regexp {query} ^[A-Z]{5}=[A-Z]{3}$
	}
	@filter2 {
		header User-Agent *ClaudeBot*
	}

	respond @filter0 403 {
		close
	}
	respond @filter1 403 {
		close
	}
	respond @filter2 403 {
		close
	}

	# Sitemap is produced by the cron SINGLETON on this edge into the `sitemap` docker volume,
	# mounted RO into `http` at /srv/femiwiki.com/sitemap. Served locally; NEVER proxied (ASG
	# nodes don't run generateSitemap). MUST be matched BEFORE the catch-all reverse_proxy,
	# else /sitemap/* would proxy to a backend with an empty sitemap/ dir -> 404. Path kept
	# identical so robots.txt (/sitemap/sitemap-index-femiwiki.xml) stays valid.
	handle /sitemap/* {
		file_server
	}

	# App traffic -> FrankenPHP ASG backends (plain HTTP :8080). The upstreams are OWNED by
	# the edge reconciler via the admin API; the @id=backend_upstreams tag is injected at
	# adapt time (Caddyfile cannot express @id). {$BACKEND_UPSTREAMS} is only a bootstrap seed.
	handle {
		reverse_proxy {$BACKEND_UPSTREAMS:127.0.0.1:8080} {
			lb_policy least_conn
			lb_try_duration 5s
			lb_try_interval 250ms

			# ACTIVE checks gate ongoing membership on process LIVENESS (not readiness), so a
			# transient shared MySQL/memcached blip cannot eject the only node fleet-wide (D4).
			# Real readiness is enforced at JOIN time by the reconciler's /healthz-ready probe
			# and at launch by the node's lifecycle-hook gate.
			health_uri /healthz-live
			health_interval 5s
			health_timeout 2s
			health_status 200
			health_passes 1
			health_fails 3

			# Passive ejection so a bad just-added upstream fails over on the request itself,
			# before the first active check (active state RESETS on every admin PATCH).
			fail_duration 30s
			max_fails 3
			unhealthy_status 5xx

			# Don't forcibly cut WebSocket/SSE/long-poll on a set-changing PATCH (default cuts
			# them). grace_period left at default (eternal) so plain in-flight HTTP requests are
			# never cut; the terminate-hook drain window keeps the old node alive until they finish.
			stream_close_delay 30s

			header_up X-Forwarded-Proto https
		}
	}

	# Steady-state has desired=1: a single-node failure (or the cold-start gap before the
	# first reconcile PATCH) leaves zero upstreams. Serve a maintenance page instead of a raw
	# 502/503 during that window (the upstream_count<1 alarm pages the operator). (D-HA)
	handle_errors {
		@down expression {http.error.status_code} in [502, 503]
		respond @down "사이트 점검 중입니다. 잠시 후 다시 시도해 주세요. (Site under maintenance, please retry shortly.)" 503 {
			close
		}
	}
}
```

Notes: this Caddyfile is baked **into** `local.femiwiki_image`. Caddy appends `X-Forwarded-For`/`-Host`; only `X-Forwarded-Proto https` is pinned (the vhost also listens on `127.0.0.1:80`/`localhost:80`). Backend trusts the edge via `trusted_proxies static {$EDGE_CIDR}` (`EDGE_CIDR=<edge_ip>/32`), and `WG_CDN_SERVERS_NO_PURGE` includes the edge IP.

---

# 6. Cron singleton + fastcgi removal + http repoint — `/home/nemo/git/fw/infra/docker/container.tf`

A new `locals.femiwiki_image` (the REBUILT image carrying the §5 Caddyfile) is used by both `http` and `cron`. `http`: `FASTCGI_ADDR` dropped, `BACKEND_UPSTREAMS=127.0.0.1:8080` seed added, `image = local.femiwiki_image`. `fastcgi` deleted. New `cron` singleton:

```hcl
locals {
  # MUST be a REBUILT image that ships the NEW reverse_proxy Caddyfile (section 5). Build +
  # push + confirm its Caddyfile adapts (section 8) BEFORE applying: removing FASTCGI_ADDR
  # while the OLD php_fastcgi Caddyfile is still baked -> adapt error -> edge DOWN.
  femiwiki_image = "ghcr.io/femiwiki/femiwiki:2026-06-28T17-00-NEWCADDY"
}

resource "docker_container" "cron" {
  name         = "cron"
  image        = local.femiwiki_image
  network_mode = "host"
  restart      = "always"

  # The image installs the schedule as ROOT'S USER CRONTAB at build time
  # (mediawiki/Dockerfile: `RUN crontab /tmp/crontab`), so `crontab -l` lists the 3 jobs.
  # env->cron bridge: cron scrubs the env; `export -p`->BASH_ENV + SHELL=/bin/bash restores
  # getenv() for LocalSettings.php. Guarded against an empty crontab; asserts run-jobs after.
  command = ["/bin/bash", "-c", <<-EOT
    set -euo pipefail
    cp -f /a/LocalSettings.php /srv/femiwiki.com/LocalSettings.php
    printf '%s' "$MEDIAWIKI_HOTFIX_SNIPPET" > /a/Hotfix.php
    mkdir -p /run/femiwiki
    export -p > /run/femiwiki/cron.env
    existing="$(crontab -l 2>/dev/null || true)"
    { printf 'SHELL=/bin/bash\nBASH_ENV=/run/femiwiki/cron.env\n'; printf '%s\n' "$existing"; } | crontab -
    crontab -l | grep -q run-jobs || { echo 'FATAL: run-jobs missing from crontab' >&2; exit 1; }
    exec cron -f
  EOT
  ]

  env = [
    for k, v in {
      MEDIAWIKI_SKIP_IMPORT_SITES = "1"
      MEDIAWIKI_SKIP_INSTALL      = "1"
      MEDIAWIKI_SKIP_UPDATE       = "1" # cron must never run update.php (no DDL drift)
      MEDIAWIKI_HOTFIX_SNIPPET    = file("res/Hotfix.php")
      WG_BOUNCE_HANDLER_INTERNAL_IPS = "172.31.0.0/16"
      WG_CDN_SERVERS                 = "127.0.0.1:80"
      WG_INTERNAL_SERVER             = "http://127.0.0.1:80"
      WG_MEMCACHED_SERVERS           = "127.0.0.1:11211"
      WG_DB_SERVER             = "${data.terraform_remote_state.aws.outputs.mysql_private_ip}:3306"
      WG_DB_USER               = local.ssm_parameters_mysql["/mysql/users/mediawiki/username"]
      WG_DB_PASSWORD           = local.ssm_parameters_mysql["/mysql/users/mediawiki/password"]
      WG_O_AUTH_2_PRIVATE_KEY  = local.ssm_parameters_mediawiki["/mediawiki/o_auth_2_private_key"]
      WG_RC_FEEDS_DISCORD_URL  = local.ssm_parameters_mediawiki["/mediawiki/rc_feeds_discord_url"]
      WG_RE_CAPTCHA_SECRET_KEY = local.ssm_parameters_mediawiki["/mediawiki/re_captcha/secret_key"]
      WG_RE_CAPTCHA_SITE_KEY   = local.ssm_parameters_mediawiki["/mediawiki/re_captcha/site_key"]
      WG_SECRET_KEY            = local.ssm_parameters_mediawiki["/mediawiki/site_key"]
      WG_SMTP_PASSWORD         = local.ssm_parameters_mediawiki["/mediawiki/smtp/password"]
      WG_SMTP_USERNAME         = local.ssm_parameters_mediawiki["/mediawiki/smtp/username"]
      WG_UPGRADE_KEY           = local.ssm_parameters_mediawiki["/mediawiki/upgrade_key"]
    } : "${k}=${v}"
  ]

  mounts {                       # owns the sitemap volume RW (from the deleted fastcgi)
    type   = "volume"
    source = docker_volume.sitemap.id
    target = "/srv/femiwiki.com/sitemap"
  }
  mounts {
    type   = "volume"
    target = "/tmp/cache"
  }
  ulimit { hard = 65536, name = "nofile", soft = 32768 }
  labels { label = "autoheal", value = "true" }
}
```

Verified from the real repo: the baked crontab is `0 1,5,9,13,17,21 generate-sitemap`, `1 5 */3 update-special-pages`, `* * * * * run-jobs` (`dockers/mediawiki/cron/crontab`), and `generateSitemap.php --fspath sitemap` writes into `/srv/femiwiki.com/sitemap` (matches the mount). Exactly one runner; ASG nodes serve only. `memcached`/`autoheal`/`backupbot` and `volume.tf` (`docker_volume.sitemap`) are unchanged (the volume is REUSED, the RW mount repointed from `fastcgi` to `cron`).

---

# 7. Workspace layout & deploy flow

**Recommendation: do NOT create a new `app` workspace — fold everything into `aws`.** Every dependency (`aws_security_group.femiwiki`, `aws_default_subnet.default["a"]`, `aws_iam_role.femiwiki`, `data.aws_caller_identity`, `aws_sns_topic.cloudwatch_alarms_topic`, the AMI data source) already lives in `aws`. Both `aws` and `docker` are VCS-driven with manual apply in TF Cloud; `docker` already consumes `aws` remote-state outputs (EIP, DB IP, SSM values, mTLS certs).

- `aws` owns: existing infra + `app.tf`, `app-iam.tf`, `app-sg.tf`, `app-ssm.tf`, `app-reconciler.tf`, the `res/` reconciler files + `user-data-app.sh.tftpl` + `Hotfix.php`, the `sg.tf` 2376 edit, the `config.alloy.tftpl` textfile edit.
- `docker` owns: `container.tf` (`http` modified, `cron` new, `fastcgi` deleted), `volume.tf` (unchanged).

**Ordered rollout (closes the high image/Caddyfile-coupling gap):**
1. **Build first.** Commit the §5 Caddyfile change in `docker-mediawiki`; CI builds + pushes the new classic image; confirm its Caddyfile adapts (§8). Set `local.femiwiki_image` to that exact tag/digest.
2. Apply `aws`: ASG/IAM/SG/SSM/reconciler-delivery/alarms. The SSM association installs the reconciler on the edge (smoke test gates it).
3. **Schema one-shot** (controlled, expand/contract) creating `objectcache` etc. — BEFORE step 4 (D-SESSION).
4. Apply `docker`: swaps `http` to `local.femiwiki_image` (new reverse_proxy Caddyfile + `BACKEND_UPSTREAMS`), deletes `fastcgi`, adds `cron`. Do NOT remove `FASTCGI_ADDR` before the image is the running tag.
5. Deploys thereafter: bump `var.app_image` → new LT version → `latest_version` increments → Rolling refresh; the maintenance policy launches node #2 (200% of 1), it self-gates on `/healthz-ready`, the reconciler add-before-removes it, then the old node drains (terminate hook + drain window) and terminates. A failed refresh auto-rolls-back; **to recover, revert `var.app_image`** (not re-apply).

---

# 8. Validation checklist (NO live apply) — results inline

```bash
# aws workspace — RAN: fmt exit 0, init -backend=false exit 0 (aws 6.30.0 + tls 4.2.1; no http provider), validate Success (+1 benign warning)
cd /home/nemo/git/fw/infra/aws && terraform fmt -check -recursive
cd /home/nemo/git/fw/infra/aws && terraform init -backend=false
cd /home/nemo/git/fw/infra/aws && terraform validate    # Success (warning: triggers=["launch_template"] redundant)

# docker workspace — RAN: fmt exit 0, init exit 0, validate Success
cd /home/nemo/git/fw/infra/docker && terraform fmt -check
cd /home/nemo/git/fw/infra/docker && terraform init -backend=false
cd /home/nemo/git/fw/infra/docker && terraform validate  # Success

# shell — RAN: shellcheck exit 0, bash -n exit 0 (reconciler); rendered installer bash -n exit 0
shellcheck /home/nemo/git/fw/infra/aws/res/femiwiki-reconciler.sh
bash -n    /home/nemo/git/fw/infra/aws/res/femiwiki-reconciler.sh
systemd-analyze verify /home/nemo/git/fw/infra/aws/res/femiwiki-reconciler.{service,timer} \
  /home/nemo/git/fw/infra/aws/res/femiwiki-reconciler-caddywatch.service  # parses (target ExecStart absent on build host = expected)

# Caddyfile — needs the CUSTOM build (mwcache/route53/s3 tokens). DEFERRED to CI (image unreachable here):
docker run --rm -v "$PWD/dockers/femiwiki:/cfg" ghcr.io/femiwiki/caddy:1.3.3 caddy validate --config /cfg/Caddyfile --adapter caddyfile
docker run --rm -v "$PWD/dockers/femiwiki:/cfg" ghcr.io/femiwiki/caddy:1.3.3 caddy adapt --config /cfg/Caddyfile --adapter caddyfile \
  | jq -e '[.. | objects | select(.handler? == "reverse_proxy")] | length == 1'   # structural pre-check passed locally
# CADDY_CONFIG_PATH smoke (on the edge, after image swap):
docker exec http caddy adapt --config /srv/femiwiki.com/Caddyfile --adapter caddyfile >/dev/null   # MUST exit 0
curl -fsS localhost:2019/id/backend_upstreams/upstreams | jq .                                     # MUST resolve after one pass
```

Local dry-run harness for the reconciler (fake admin API echoing the PATCH + an `aws` shim returning canned `describe-*`) still applies: assert floor-of-one holds on an empty mock, `Terminating:Wait` heartbeats until `DRAIN_WINDOW` then `CONTINUE`, and a live-but-not-ready new node is HELD out of upstreams.

**Verifiable only at apply time (operator):** the launch hook holds `Pending:Wait` until `/healthz-ready`; the maintenance policy honors transient-2 launch-before-terminate; node IAM resolves `ssm:GetParameter --with-decryption` on `/mediawiki/* /mysql/* /alloy/*` without `AccessDenied` (default `aws/ssm` KMS key); the PATCH drops zero in-flight HTTP requests under load; the 2376 TFC-IP list still lets the `docker` workspace apply; the cron env→cron bridge connects a real `run-jobs` to MySQL; and **the schema migration creating `objectcache` ran BEFORE the first ASG node** (CACHE_DB session store + one-time logout at cutover — D-SESSION).

---

# 9. Open decisions for the operator

- **D1 — terminate hook fail mode.** `default_result=CONTINUE` (fail-open; a reconciler outage lets a node terminate after 180s, mitigated by the drain window + Caddy active/passive checks). Hard guarantee = `ABANDON` + retain-on-`TerminateHookAbandon` (standby charges).
- **D2 — 2376 close strength.** Static TFC API CIDRs (shipped) vs `data.http` (rejected: plan-time dependency/lockout) vs moving the `docker` provider off network Docker (SSM tunnel). Re-verify the two CIDRs periodically.
- **D3 — `purge_acl` breadth.** `172.31.0.0/16` (VPC-wide) vs tighter `<edge_ip>/32`.
- **D4 — health target split (shipped).** Caddy active = `/healthz-live`; readiness = join-gate + launch-gate + (optional) slow alarm-only probe. Closes the shared-dep cascade.
- **D5 — `Hotfix.php` duplication.** `aws/res/Hotfix.php` is a byte-copy of `docker/res/Hotfix.php`; keep in sync or promote to one SSM parameter.
- **D6 — least-privilege trims.** Unused `autoscaling:DescribeAutoScalingGroups`/`DescribeLifecycleHooks` (Reconciler) and `ssm:GetParameters`/`GetParametersByPath` (AppNode) may be dropped; `kms:Decrypt` redundant if all SecureStrings use the default key.
- **D7 — sitemap freshness on edge rebuild.** Empty `sitemap` volume → `/sitemap` 404s until the next `generate-sitemap` (≤~4h). Accept, or prepend one `generateSitemap.php` run to the `cron` command before `exec cron -f`.
- **D8 — FrankenPHP thread/connection sizing.** `app_frankenphp_num_threads=8`: `threads*128M + 512M opcache` must fit 2 GB; `nodes*threads*connects_per_request` under MariaDB `max_connections`. Soak before raising.
- **D9 — reconciler language.** Bash one-shot now; drop-in Go `Type=notify` daemon only if poll rate must drop below ~5s.
- **D10 — image pinning.** Pin `var.app_image` and `local.femiwiki_image` by `@sha256:` in prod so refresh/rollback converge on a known artifact.
- **D-HA — steady-state redundancy.** `desired=1` = zero-downtime for DEPLOYS only; an unplanned single-node failure has a launch+gate RTO (minutes), covered by the `handle_errors` maintenance page + the `upstream_count<1` alarm. Run `desired=2` (`min=2,max=3`) for real HA if the RTO is unacceptable.
- **D-SESSION — cutover.** Backend overrides `$wgSessionCacheType` to CACHE_DB; the schema migration creating `objectcache` is a HARD prerequisite before the first ASG node, and cutover from memcached sessions invalidates all logged-in sessions (one-time mass logout) — sequence it in the runbook.

---

Files on disk (all absolute). NEW: `/home/nemo/git/fw/infra/aws/res/femiwiki-reconciler.sh`, `…/femiwiki-reconciler.env`, `…/femiwiki-reconciler.service`, `…/femiwiki-reconciler.timer`, `…/femiwiki-reconciler-caddywatch.service`, `…/install-reconciler.sh.tftpl`, `/home/nemo/git/fw/infra/aws/app-reconciler.tf`. EDITED: `/home/nemo/git/fw/infra/aws/sg.tf`, `/home/nemo/git/fw/infra/aws/app.tf`, `/home/nemo/git/fw/infra/aws/res/config.alloy.tftpl`, `/home/nemo/git/fw/infra/docker/container.tf`, `/home/nemo/git/fw/docker-mediawiki/dockers/femiwiki/Caddyfile`. ALREADY-PRESENT + validated unchanged: `/home/nemo/git/fw/infra/aws/app-iam.tf`, `app-sg.tf`, `app-ssm.tf`, `res/user-data-app.sh.tftpl`, `res/Hotfix.php`. `base.tf` intentionally NOT changed (static 2376 list needs no `http` provider).