### PR TITLE
chore(github): drop required PR reviews from default branch protection

### DIFF
--- a/github/modules/github-repository/variables.tf
+++ b/github/modules/github-repository/variables.tf
@@ -47,13 +47,7 @@ variable "required_pull_request_reviews" {
     require_code_owner_reviews      = bool,
     required_approving_review_count = number,
   }))
-  default = [
-    {
-      dismiss_stale_reviews           = false,
-      require_code_owner_reviews      = false,
-      required_approving_review_count = 1,
-    }
-  ]
+  default = []
 }
 
 variable "required_status_checks_contexts" {


### PR DESCRIPTION
## Summary

The `github-repository` module defaulted `required_pull_request_reviews` to **1 approving review**. With too few active maintainers, no reviewer is available, so PRs (including Dependabot) get stuck in a `BLOCKED` state and cannot merge. This changes the module default to `[]` (no required reviews).

Only repos that relied on the module default were still enforcing a review; the CD/bot/docker repos already pass `required_pull_request_reviews = []` explicitly, so they are unaffected.

## Terraform plan (8 branch protections updated in-place)

Required-review enforcement is removed from:

- `caddy-mwcache`
- `legunto`
- `maintenance`
- `remote-gadgets`
- `OOUIFemiwikiTheme`
- `lambda`
- `terraform-provider-mediawiki`
- `.github`

**Unchanged**: linear history, required status checks, and `enforce_admins`.

> Note: a full `terraform plan` on the current workspace also shows an unrelated pending `module.nomad.github_repository` destroy that predates this branch. That is **not** part of this change; apply only the 8 `branch_protection` targets (or resolve the nomad drift separately).

## Motivation

Unblocks the consolidated dependency PR on `caddy-mwcache` (femiwiki/caddy-mwcache#98) and future Dependabot PRs across these repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)