### PR TITLE
github: require the zizmor check by default, opt out where unused

### DIFF
--- a/github/modules/github-repository/main.tf
+++ b/github/modules/github-repository/main.tf
@@ -27,6 +27,14 @@ resource "github_branch_default" "branch_default" {
   branch     = github_branch.main_branch.branch
 }
 
+locals {
+  # Repo-specific checks plus the org-wide defaults (deduped).
+  status_check_contexts = distinct(concat(
+    var.required_status_checks_contexts,
+    var.default_status_checks,
+  ))
+}
+
 resource "github_branch_protection" "branch_protection" {
   count                   = length(var.patterns)
   repository_id           = github_repository.repository.node_id
@@ -35,7 +43,7 @@ resource "github_branch_protection" "branch_protection" {
   required_linear_history = true
 
   dynamic "required_status_checks" {
-    for_each = var.required_status_checks_contexts
+    for_each = length(local.status_check_contexts) > 0 ? [local.status_check_contexts] : []
     content {
       strict   = false
       contexts = required_status_checks.value

--- a/github/modules/github-repository/variables.tf
+++ b/github/modules/github-repository/variables.tf
@@ -51,9 +51,15 @@ variable "required_pull_request_reviews" {
 }
 
 variable "required_status_checks_contexts" {
-  description = ""
-  type        = list(list(string))
+  description = "Repo-specific required status checks (org-wide ones are added automatically)"
+  type        = list(string)
   default     = []
+}
+
+variable "default_status_checks" {
+  description = "Status checks required on every repo unless overridden"
+  type        = list(string)
+  default     = ["zizmor"]
 }
 
 variable "collaborator" {

--- a/github/repo-extension.tf
+++ b/github/repo-extension.tf
@@ -24,13 +24,13 @@ module "femiwiki_skin" {
   ]
   enforce_admins                = local.extension.enforce_admins
   required_pull_request_reviews = local.extension.required_pull_request_reviews
-  required_status_checks_contexts = [[
+  required_status_checks_contexts = [
     "test (REL1_43, composer-test)",
     "test (REL1_43, npm-test)",
     "test (REL1_43, phan)",
     # "test (REL1_43, selenium)",
     "semantic-pull-request",
-  ]]
+  ]
   patterns     = ["main"]
   collaborator = local.extension.collaborator
 }
@@ -43,12 +43,12 @@ module "unified_extension_for_femiwiki" {
   topics                        = ["mediawiki-extension"]
   enforce_admins                = local.extension.enforce_admins
   required_pull_request_reviews = local.extension.required_pull_request_reviews
-  required_status_checks_contexts = [[
+  required_status_checks_contexts = [
     "test (REL1_43, composer-test)",
     "test (REL1_43, npm-test)",
     "test (REL1_43, phan)",
     "test (REL1_43, selenium)",
-  ]]
+  ]
   patterns     = ["main"]
   collaborator = local.extension.collaborator
 }
@@ -61,12 +61,12 @@ module "femiwiki_crawling_blocker" {
   topics                        = ["mediawiki-extension"]
   enforce_admins                = local.extension.enforce_admins
   required_pull_request_reviews = local.extension.required_pull_request_reviews
-  required_status_checks_contexts = [[
+  required_status_checks_contexts = [
     "test (REL1_43, composer-test)",
     "test (REL1_43, npm-test)",
     "test (REL1_43, phan)",
     "test (REL1_43, selenium)",
-  ]]
+  ]
   patterns     = ["main"]
   collaborator = local.extension.collaborator
 }

--- a/github/repo.tf
+++ b/github/repo.tf
@@ -26,10 +26,10 @@ module "infra" {
 }
 
 module "femiwiki" {
-  source       = "./modules/github-repository"
-  name         = "femiwiki"
-  description  = ":earth_asia: 문서화된 페미위키 기술 정보 및 이슈 트래킹 정보 제공"
-  homepage_url = "https://femiwiki.com"
+  source                        = "./modules/github-repository"
+  name                          = "femiwiki"
+  description                   = ":earth_asia: 문서화된 페미위키 기술 정보 및 이슈 트래킹 정보 제공"
+  homepage_url                  = "https://femiwiki.com"
   required_pull_request_reviews = local.default_repo.required_pull_request_reviews
   topics = [
     "feminism",
@@ -44,7 +44,7 @@ module "docker_mediawiki" {
   delete_branch_on_merge          = true
   enforce_admins                  = local.docker.enforce_admins
   required_pull_request_reviews   = local.docker.required_pull_request_reviews
-  required_status_checks_contexts = [["php-lint", "caddy-fmt", "etc-lint"]]
+  required_status_checks_contexts = ["php-lint", "caddy-fmt", "etc-lint"]
   topics = [
     "docker-compose",
     "docker-image",
@@ -71,6 +71,7 @@ module "backupbot" {
   description                   = ":robot: 페미위키 MySQL 백업봇"
   enforce_admins                = local.bot.enforce_admins
   required_pull_request_reviews = local.bot.required_pull_request_reviews
+  default_status_checks         = []
   topics = [
     "bot",
     "docker-image",
@@ -92,34 +93,38 @@ module "tweetbot" {
 }
 
 module "remote_gadgets" {
-  source      = "./modules/github-repository"
-  name        = "remote-gadgets"
-  description = "📽️ External repository for JavaScript/CSS on Femiwiki"
+  source                = "./modules/github-repository"
+  name                  = "remote-gadgets"
+  description           = "📽️ External repository for JavaScript/CSS on Femiwiki"
+  default_status_checks = []
   topics = [
     "bot",
   ]
 }
 
 module "dot_github" {
-  source      = "./modules/github-repository"
-  name        = ".github"
-  description = "Community health files"
+  source                = "./modules/github-repository"
+  name                  = ".github"
+  description           = "Community health files"
+  default_status_checks = []
 }
 
 module "legunto" {
-  source      = "./modules/github-repository"
-  name        = "legunto"
-  description = "Fetch MediaWiki Scribunto modules from wikis"
+  source                = "./modules/github-repository"
+  name                  = "legunto"
+  description           = "Fetch MediaWiki Scribunto modules from wikis"
+  default_status_checks = []
   topics = [
     "scribunto",
   ]
 }
 
 module "maintenance" {
-  source       = "./modules/github-repository"
-  name         = "maintenance"
-  description  = ":wrench: 페미위키 점검 페이지"
-  homepage_url = "https://femiwiki.github.io/maintenance"
+  source                = "./modules/github-repository"
+  name                  = "maintenance"
+  description           = ":wrench: 페미위키 점검 페이지"
+  homepage_url          = "https://femiwiki.github.io/maintenance"
+  default_status_checks = []
   topics = [
     "website",
   ]
@@ -141,9 +146,10 @@ module "caddy_mwcache" {
 }
 
 module "ooui_femiwiki_theme" {
-  source      = "./modules/github-repository"
-  name        = "OOUIFemiwikiTheme"
-  description = ":jack_o_lantern: OOUI Femiwiki Theme"
+  source                = "./modules/github-repository"
+  name                  = "OOUIFemiwikiTheme"
+  description           = ":jack_o_lantern: OOUI Femiwiki Theme"
+  default_status_checks = []
   topics = [
     "ooui-theme",
     "ooui",
@@ -163,22 +169,20 @@ module "quibble_action" {
 
   required_pull_request_reviews = []
   required_status_checks_contexts = [
-    [
-      "zizmor",
-      "semantic-pull-request",
-      "yamllint",
-      "ruff",
-      "actionlint",
-      "biome",
-      "rumdl",
-    ]
+    "semantic-pull-request",
+    "yamllint",
+    "ruff",
+    "actionlint",
+    "biome",
+    "rumdl",
   ]
 }
 
 module "lambda" {
-  source      = "./modules/github-repository"
-  name        = "lambda"
-  description = "A simple lambda function which subscribes AWS SNS to ping Femiwiki's Discord webhook."
+  source                = "./modules/github-repository"
+  name                  = "lambda"
+  description           = "A simple lambda function which subscribes AWS SNS to ping Femiwiki's Discord webhook."
+  default_status_checks = []
   topics = [
     "lambda",
     "aws",
@@ -187,9 +191,10 @@ module "lambda" {
 }
 
 module "terraform-provider-mediawiki" {
-  source      = "./modules/github-repository"
-  name        = "terraform-provider-mediawiki"
-  description = "💜"
+  source                = "./modules/github-repository"
+  name                  = "terraform-provider-mediawiki"
+  description           = "💜"
+  default_status_checks = []
   topics = [
     "mediawiki",
     "terraform-provider",


### PR DESCRIPTION
Makes the `zizmor` security check a **required status check** org-wide, using a default-on / opt-out model, and simplifies the module's status-check handling.

## How

- New `default_status_checks` module variable (default **["zizmor"]**), appended to every repo's `required_status_checks` and deduped. Adding another org-wide check later (e.g. `rumdl`) is a one-line change to the default.
- Repos **without** the zizmor workflow opt out with `default_status_checks = []`: `backupbot`, `remote-gadgets`, `.github`, `legunto`, `maintenance`, `OOUIFemiwikiTheme`, `lambda`, `terraform-provider-mediawiki`.
- `required_status_checks_contexts` is flattened from `list(list(string))` to `list(string)` — GitHub only supports one `required_status_checks` block, so the outer list was needless nesting that made the merge logic hard to read.
- `quibble-action`'s explicit `"zizmor"` context is dropped since the default supplies it.

`terraform validate` passes.

## ⚠️ Apply ordering

Apply **only after** the zizmor workflow is merged on every default branch this covers — all of them **except FemiwikiSkin** (femiwiki/FemiwikiSkin#968 is auto-merge-pending) as of writing. Requiring a `zizmor` context on a branch with no zizmor workflow would block all its PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)