### PR TITLE
aws: add lambda config perms and switch github-lambda to OIDC

### DIFF
--- a/aws/iam-policies.tf
+++ b/aws/iam-policies.tf
@@ -250,7 +250,11 @@ data "aws_iam_policy_document" "ses_sending_access" {
 
 data "aws_iam_policy_document" "github_lambda" {
   statement {
-    actions = ["lambda:UpdateFunctionCode"]
+    actions = [
+      "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+      "lambda:GetFunctionConfiguration",
+    ]
     resources = [
       "arn:aws:lambda:ap-northeast-1:302617221463:function:DiscordNoti",
       "arn:aws:lambda:us-east-1:302617221463:function:DiscordNoti",

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -81,6 +81,41 @@ resource "aws_iam_group_policy_attachment" "readonly_mfa" {
 #
 # IAM Roles
 #
+resource "aws_iam_role" "github_lambda" {
+  name               = "github-lambda"
+  description        = "Allows GitHub Actions workflows of femiwiki/lambda to deploy the DiscordNoti function."
+  assume_role_policy = data.aws_iam_policy_document.github_lambda_assume_role.json
+}
+
+data "aws_iam_policy_document" "github_lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:femiwiki/lambda:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "github_lambda" {
+  name   = "GithubLambda"
+  role   = aws_iam_role.github_lambda.name
+  policy = data.aws_iam_policy_document.github_lambda.json
+}
+
 resource "aws_iam_role" "femiwiki" {
   name               = "Femiwiki"
   description        = "Allows EC2 instances to call AWS services on your behalf."


### PR DESCRIPTION
## Summary
- Adds `lambda:UpdateFunctionConfiguration` and `lambda:GetFunctionConfiguration` to the `github_lambda` policy, needed for femiwiki/lambda#188's declarative runtime/handler step (closes #478)
- Replaces the long-lived `github-lambda` IAM user credentials with an IAM role assumed via the existing GitHub Actions OIDC provider, scoped to `repo:femiwiki/lambda:ref:refs/heads/main`
- Companion change on the workflow side: femiwiki/lambda#188 now uses `role-to-assume` instead of static access keys

## Notes
- The `github-lambda` IAM user is intentionally left in place for now so nothing breaks before the OIDC deploy is verified. Once a deploy succeeds via the new role, the user, its access keys, and the `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets in femiwiki/lambda should be removed in a follow-up.
- This must be applied before femiwiki/lambda#188 is merged, or the first deploy under the new role/permissions will fail.

## Test plan
- [x] `terraform fmt -check`
- [x] `terraform validate`
- [ ] `terraform plan` reviewed by a human before apply
- [ ] After apply, merge femiwiki/lambda#188 and confirm the deploy job assumes the role and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)