### PR TITLE
Add a dedicated, cleanly-named execution role for DiscordNoti

### DIFF
--- a/aws/cloudwatch.tf
+++ b/aws/cloudwatch.tf
@@ -1,3 +1,13 @@
+resource "aws_cloudwatch_log_group" "discord_noti" {
+  name = "/aws/lambda/DiscordNoti"
+}
+
+resource "aws_cloudwatch_log_group" "discord_noti_us" {
+  provider = aws.us
+
+  name = "/aws/lambda/DiscordNoti"
+}
+
 resource "aws_cloudwatch_metric_alarm" "femiwiki_volume_idle_time_cloud_watch_alarm" {
   alarm_name  = "Femiwiki VolumeIdleTime"
   namespace   = "AWS/EBS"

--- a/aws/iam-policies.tf
+++ b/aws/iam-policies.tf
@@ -270,8 +270,8 @@ data "aws_iam_policy_document" "discord_noti" {
       "logs:PutLogEvents",
     ]
     resources = [
-      "arn:aws:logs:ap-northeast-1:302617221463:log-group:/aws/lambda/DiscordNoti:*",
-      "arn:aws:logs:us-east-1:302617221463:log-group:/aws/lambda/DiscordNoti:*",
+      aws_cloudwatch_log_group.discord_noti.arn,
+      aws_cloudwatch_log_group.discord_noti_us.arn,
     ]
   }
 

--- a/aws/iam-policies.tf
+++ b/aws/iam-policies.tf
@@ -262,6 +262,26 @@ data "aws_iam_policy_document" "github_lambda" {
   }
 }
 
+data "aws_iam_policy_document" "discord_noti" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = [
+      "arn:aws:logs:ap-northeast-1:302617221463:log-group:/aws/lambda/DiscordNoti:*",
+      "arn:aws:logs:us-east-1:302617221463:log-group:/aws/lambda/DiscordNoti:*",
+    ]
+  }
+
+  statement {
+    # GetMetricWidgetImage does not support resource-level permissions.
+    actions   = ["cloudwatch:GetMetricWidgetImage"]
+    resources = ["*"]
+  }
+}
+
 data "aws_iam_policy_document" "iac" {
   statement {
     actions = [

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -116,6 +116,29 @@ resource "aws_iam_role_policy" "github_lambda" {
   policy = data.aws_iam_policy_document.github_lambda.json
 }
 
+resource "aws_iam_role" "discord_noti" {
+  name               = "DiscordNoti"
+  description        = "Execution role for the DiscordNoti Lambda function."
+  assume_role_policy = data.aws_iam_policy_document.discord_noti_assume_role.json
+}
+
+data "aws_iam_policy_document" "discord_noti_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "discord_noti" {
+  name   = "DiscordNoti"
+  role   = aws_iam_role.discord_noti.name
+  policy = data.aws_iam_policy_document.discord_noti.json
+}
+
 resource "aws_iam_role" "femiwiki" {
   name               = "Femiwiki"
   description        = "Allows EC2 instances to call AWS services on your behalf."


### PR DESCRIPTION
Prep work for an upcoming femiwiki/lambda change that attaches a CloudWatch metric chart to alarm notifications (needs `cloudwatch:GetMetricWidgetImage`).

## Why a new role instead of importing the existing one

DiscordNoti's execution role (`DiscordNoti-role-pf7hm8uw`) is a console-generated role never tracked in Terraform. Importing it would permanently bake that random suffix into `name` in the HCL (IAM role names force a replace on change, so it could never be cleaned up afterward). Creating a fresh, cleanly-named role (`DiscordNoti`) avoids that.

## What this does

- New `aws_iam_role.discord_noti` + inline policy: CloudWatch Logs write actions (scoped to this function's log groups in both regions) and `cloudwatch:GetMetricWidgetImage` (`*` only — the action has no resource-level permissions).
- New `aws_cloudwatch_log_group` resources for both regions, referenced by ARN from the IAM policy instead of hardcoded strings.

## Found along the way

The currently-attached policy on the *old* role (`AWSLambdaBasicExecutionRole-c0739fc4-...`) turned out to be scoped to `us-east-1` only. The ap-northeast-1 function has apparently never been able to write to CloudWatch Logs — no log group exists there. The new role's policy is scoped to both regions from the start, so this incidentally fixes that.

The old us-east-1 log group held only two manual test invocations from verifying the sns-discord Python rewrite, so it was deleted directly (not imported) — this lets Terraform create both regions' log groups fresh instead of needing an import (this backend's remote execution mode doesn't support `terraform import` anyway).

## Not done here

This PR only creates the new role — it does not switch the Lambda function's `Role` over yet. That's a manual, low-risk swap (the function is called infrequently) done separately after this applies and the new role is confirmed to exist. The old role (`DiscordNoti-role-pf7hm8uw`) and its dedicated policy are left in place until the swap is verified, then will be deleted by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)