### PR TITLE
Fix DiscordNoti log permissions: append :* for stream-level actions

### DIFF
--- a/aws/iam-policies.tf
+++ b/aws/iam-policies.tf
@@ -272,9 +272,6 @@ data "aws_iam_policy_document" "discord_noti" {
   }
 
   statement {
-    # CreateLogStream/PutLogEvents act on log streams, a sub-resource of the
-    # group, so the ARN needs the trailing :* that aws_cloudwatch_log_group's
-    # own arn attribute omits.
     actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",

--- a/aws/iam-policies.tf
+++ b/aws/iam-policies.tf
@@ -264,14 +264,24 @@ data "aws_iam_policy_document" "github_lambda" {
 
 data "aws_iam_policy_document" "discord_noti" {
   statement {
+    actions = ["logs:CreateLogGroup"]
+    resources = [
+      aws_cloudwatch_log_group.discord_noti.arn,
+      aws_cloudwatch_log_group.discord_noti_us.arn,
+    ]
+  }
+
+  statement {
+    # CreateLogStream/PutLogEvents act on log streams, a sub-resource of the
+    # group, so the ARN needs the trailing :* that aws_cloudwatch_log_group's
+    # own arn attribute omits.
     actions = [
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]
     resources = [
-      aws_cloudwatch_log_group.discord_noti.arn,
-      aws_cloudwatch_log_group.discord_noti_us.arn,
+      "${aws_cloudwatch_log_group.discord_noti.arn}:*",
+      "${aws_cloudwatch_log_group.discord_noti_us.arn}:*",
     ]
   }
 


### PR DESCRIPTION
Follow-up to #480. After merging that and swapping the DiscordNoti function's execution role over, verified the function could invoke and post to Discord fine (204), but its ap-northeast-1 log group had zero log streams despite successful invokes — the function still couldn't write logs.

Root cause: `aws_cloudwatch_log_group.arn` returns the ARN without the trailing `:*` (matches CloudWatch Logs API's `logGroupArn` field, not its `arn` field). `logs:CreateLogStream`/`PutLogEvents` act on log streams — a sub-resource of the group — so they need the `:*`-suffixed form to match. `logs:CreateLogGroup` acts on the group itself and is correctly scoped without it, so it's split into its own statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)